### PR TITLE
implement methods on types as traits so that they can be abstracted t…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,6 +3226,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusty-coin"
+version = "0.1.0"
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+workspace = { members = ["payload/hello-rusty/rusty-coin"] }
 [package]
 name = "lasr"
 version = "0.1.0"

--- a/src/actors/account_cache.rs
+++ b/src/actors/account_cache.rs
@@ -1,5 +1,11 @@
 use crate::{
-    Account, AccountCacheMessage, Address, RpcMessage, RpcResponseError, TransactionResponse,
+    Account, 
+    AccountCacheMessage, 
+    Address, 
+    RpcMessage, 
+    RpcResponseError, 
+    TransactionResponse,
+    interfaces::accounts::ProtocolAccount
 };
 use async_trait::async_trait;
 use futures::stream::FuturesUnordered;

--- a/src/actors/batcher.rs
+++ b/src/actors/batcher.rs
@@ -1,12 +1,35 @@
 #![allow(unused)]
-use std::{collections::{HashMap, VecDeque, BTreeMap, BTreeSet, HashSet}, fmt::Display};
+use std::{
+    collections::{
+        HashMap, 
+        VecDeque, 
+        BTreeMap, 
+        BTreeSet, 
+        HashSet
+    }, 
+    fmt::Display
+};
 
 use sha3::{Digest, Keccak256};
 use async_trait::async_trait;
-use eigenda_client::{batch, proof::BlobVerificationProof, response::BlobResponse};
+use eigenda_client::{
+    batch, 
+    proof::BlobVerificationProof, 
+    response::BlobResponse
+};
 use ethereum_types::H256;
 use futures::stream::{FuturesUnordered, StreamExt};
-use ractor::{Actor, ActorRef, ActorProcessingErr, factory::CustomHashFunction, concurrency::{oneshot, OneshotReceiver}, ActorCell};
+use ractor::{
+    Actor, 
+    ActorRef, 
+    ActorProcessingErr, 
+    factory::CustomHashFunction, 
+    concurrency::{
+        oneshot, 
+        OneshotReceiver
+    }, 
+    ActorCell
+};
 use serde::{Serialize, Deserialize};
 use serde_json::Value;
 use thiserror::Error;
@@ -15,7 +38,47 @@ use web3::types::BlockNumber;
 use std::io::Write;
 use flate2::{Compression, write::{ZlibEncoder, ZlibDecoder}};
 
-use crate::{Transaction, Account, BatcherMessage, get_account, AccountBuilder, AccountCacheMessage, ActorType, SchedulerMessage, DaClientMessage, handle_actor_response, EoMessage, Address, Namespace, ProgramAccount, Metadata, ArbitraryData, program, Instruction, AddressOrNamespace, AccountType, TokenOrProgramUpdate, ContractLogType, TransferInstruction, BurnInstruction, U256, TokenDistribution, TokenUpdate, ProgramUpdate, UpdateInstruction, PendingTransactionMessage, TransactionType, Outputs, CreateInstruction, MetadataValue, create_program_id};
+use crate::{
+    Transaction, 
+    Account, 
+    BatcherMessage, 
+    get_account, 
+    AccountBuilder, 
+    AccountCacheMessage, 
+    ActorType, 
+    SchedulerMessage, 
+    DaClientMessage, 
+    handle_actor_response, 
+    EoMessage, 
+    Address, 
+    Namespace, 
+    ProgramAccount, 
+    Metadata, 
+    ArbitraryData, 
+    program, 
+    Instruction, 
+    AddressOrNamespace, 
+    AccountType, 
+    TokenOrProgramUpdate, 
+    ContractLogType, 
+    TransferInstruction, 
+    BurnInstruction, 
+    U256, 
+    TokenDistribution, 
+    TokenUpdate, 
+    ProgramUpdate, 
+    UpdateInstruction, 
+    PendingTransactionMessage, 
+    TransactionType, 
+    Outputs, 
+    CreateInstruction, 
+    MetadataValue, 
+    create_program_id,
+    interfaces::{
+        accounts::ProtocolAccount,
+        transactions::ProtocolTransaction
+    }
+};
 
 // const BATCH_INTERVAL: u64 = 180;
 pub type PendingReceivers = FuturesUnordered<OneshotReceiver<(String, BlobVerificationProof)>>;

--- a/src/actors/engine.rs
+++ b/src/actors/engine.rs
@@ -8,7 +8,38 @@ use serde_json::Value;
 use thiserror::Error;
 use sha3::{Digest, Keccak256};
 use futures::{stream::{iter, Then, StreamExt}, TryFutureExt};
-use crate::{Account, BridgeEvent, Metadata, Status, Address, create_handler, EoMessage, handle_actor_response, DaClientMessage, AccountCacheMessage, Token, TokenBuilder, ArbitraryData, TransactionBuilder, TransactionType, Transaction, PendingTransactionMessage, RecoverableSignature, check_da_for_account, check_account_cache, ExecutorMessage, Outputs, AddressOrNamespace, ValidatorMessage, AccountType, SchedulerMessage};
+use crate::{
+    Account, 
+    BridgeEvent, 
+    Metadata, 
+    Status, 
+    Address, 
+    create_handler, 
+    EoMessage, 
+    handle_actor_response, 
+    DaClientMessage, 
+    AccountCacheMessage, 
+    Token, 
+    TokenBuilder, 
+    ArbitraryData, 
+    TransactionBuilder, 
+    TransactionType, 
+    Transaction, 
+    PendingTransactionMessage, 
+    RecoverableSignature, 
+    check_da_for_account, 
+    check_account_cache, 
+    ExecutorMessage, 
+    Outputs,
+    AddressOrNamespace, 
+    ValidatorMessage, 
+    AccountType, 
+    SchedulerMessage,
+    interfaces::{
+        accounts::ProtocolAccount,
+        transactions::ProtocolTransaction
+    }
+};
 use jsonrpsee::{core::Error as RpcError, tracing::trace_span};
 use tokio::sync::mpsc::Sender;
 

--- a/src/actors/executor.rs
+++ b/src/actors/executor.rs
@@ -4,11 +4,24 @@ use std::time::Duration;
 use jsonrpsee::{ws_client::WsClient, core::client::ClientT};
 use ractor::{Actor, ActorRef, ActorProcessingErr};
 use async_trait::async_trait;
-use crate::get_account;
 #[cfg(feature = "local")]
-use crate::{Address, ExecutorMessage, Inputs, Required, ProgramSchema, SchedulerMessage, ActorType, EngineMessage, Transaction, OciManager};
+use crate::{
+    ExecutorMessage, 
+    Inputs, Required, 
+    ProgramSchema, 
+    SchedulerMessage, 
+    ActorType, 
+    EngineMessage, 
+    Transaction, 
+    OciManager,
+    get_account,
+    interfaces::{
+        accounts::ProtocolAccount,
+        transactions::ProtocolTransaction
+    }
+};
 #[cfg(feature = "remote")]
-use crate::{get_account, BatcherMessage};
+use crate::{get_account, BatcherMessage, interfaces::accounts::ProtocolAccount};
 use serde::{Serialize, Deserialize};
 use tokio::{task::JoinHandle, sync::mpsc::Sender};
 #[cfg(feature = "remote")]

--- a/src/actors/pending_transactions.rs
+++ b/src/actors/pending_transactions.rs
@@ -6,7 +6,9 @@ use crate::{
     ActorType,
     ValidatorMessage,
     Outputs,
-    AddressOrNamespace, TransactionType
+    AddressOrNamespace, 
+    TransactionType,
+    interfaces::transactions::ProtocolTransaction
 };
 use async_trait::async_trait;
 use ractor::{Actor, ActorRef, ActorProcessingErr};

--- a/src/actors/scheduler.rs
+++ b/src/actors/scheduler.rs
@@ -3,7 +3,17 @@ use std::{collections::HashMap, fmt::Display};
 use async_trait::async_trait;
 use ractor::{ActorRef, Actor, ActorProcessingErr, concurrency::oneshot, RpcReplyPort};
 use thiserror::*;
-use crate::{account::Address, create_handler, RecoverableSignature, AccountCacheMessage, check_account_cache, TransactionResponse, check_da_for_account, Transaction};
+use crate::{
+    account::Address, 
+    create_handler, 
+    RecoverableSignature, 
+    AccountCacheMessage, 
+    check_account_cache, 
+    TransactionResponse, 
+    check_da_for_account, 
+    Transaction,
+    interfaces::transactions::ProtocolTransaction
+};
 use super::{messages::{RpcMessage, ValidatorMessage, EngineMessage, SchedulerMessage, RpcResponseError, EoMessage, DaClientMessage}, types::ActorType, handle_actor_response, eo_server, da_client};
 use jsonrpsee::core::Error as RpcError;
 

--- a/src/actors/validator.rs
+++ b/src/actors/validator.rs
@@ -10,7 +10,17 @@ use crate::{
     check_account_cache, 
     check_da_for_account, 
     ActorType, 
-    PendingTransactionMessage, AddressOrNamespace, Outputs, Instruction, TokenOrProgramUpdate, TokenFieldValue, BatcherMessage
+    PendingTransactionMessage, 
+    AddressOrNamespace, 
+    Outputs, 
+    Instruction, 
+    TokenOrProgramUpdate, 
+    TokenFieldValue, 
+    BatcherMessage,
+    interfaces::{
+        accounts::ProtocolAccount,
+        transactions::ProtocolTransaction
+    }
 };
 
 use super::messages::ValidatorMessage;

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -12,8 +12,33 @@ use secp256k1::PublicKey;
 use walkdir::WalkDir;
 use hex::ToHex;
 use jsonrpsee::{http_client::{HttpClient, HttpClientBuilder}, core::client::ClientT};
-use lasr::{Transaction, Instruction, CreateInstruction, TransferInstruction, UpdateInstruction, BurnInstruction, LasrPackageType, LasrPackageBuilder, LasrObjectBuilder, LasrObjectPayloadBuilder, LasrContentType, LasrObjectCid, SignableObject, LasrObject, LasrPackagePayloadBuilder, LasrPackage};
-use lasr::{account::Address, WalletBuilder, Wallet, PayloadBuilder, LasrRpcClient, Account, WalletInfo, Namespace};
+use lasr::{
+    Transaction, 
+    Instruction, 
+    CreateInstruction, 
+    TransferInstruction, 
+    UpdateInstruction, 
+    BurnInstruction, 
+    LasrPackageType, 
+    LasrPackageBuilder, 
+    LasrObjectBuilder, 
+    LasrObjectPayloadBuilder, 
+    LasrContentType, 
+    LasrObjectCid, 
+    SignableObject, 
+    LasrObject, 
+    LasrPackagePayloadBuilder, 
+    LasrPackage,
+    interfaces::accounts::ProtocolAccount,
+    account::Address, 
+    WalletBuilder, 
+    Wallet, 
+    PayloadBuilder, 
+    LasrRpcClient, 
+    Account, 
+    WalletInfo, 
+    Namespace
+};
 use secp256k1::{SecretKey, Secp256k1, rand::rngs::OsRng, Keypair}; 
 use ethereum_types::{Address as EthereumAddress, U256};
 use bip39::{Mnemonic, Language};
@@ -805,8 +830,8 @@ async fn recursively_publish_objects(
             if *verbose { println!("published {} to Web3Store, CID: {}", path.to_string_lossy().to_string(), &cid); }
             let mut payload_builder = LasrObjectPayloadBuilder::default()
                 .object_cid(LasrObjectCid::from(cid.clone()))
-                .object_path(path.clone().to_string_lossy().to_string())
-                .object_content_type(LasrContentType::from(PathBuf::from(path.clone()))).clone();
+                .object_path(path.to_string_lossy().to_string())
+                .object_content_type(LasrContentType::from(PathBuf::from(path))).clone();
 
             if let Some(inner_annots) = annotations.get(&path.to_string_lossy().to_string()) {
                 if let Ok(annots) = serde_json::from_str(inner_annots) {
@@ -817,7 +842,7 @@ async fn recursively_publish_objects(
             let object_payload = payload_builder.build()?;
             let object_sig = object_payload.sign(&sk)?;
             let object = LasrObject { object_payload, object_sig };
-            if *verbose { println!("Successfully published: {}, CID: {}", path.clone().to_string_lossy().to_string(), &cid) };
+            if *verbose { println!("Successfully published: {}, CID: {}", path.to_string_lossy().to_string(), &cid) };
             objects.push(object); 
         }
     }

--- a/src/clients/wallet.rs
+++ b/src/clients/wallet.rs
@@ -13,6 +13,10 @@ use crate::{
     Account, 
     RecoverableSignature, 
     Transaction, Token, Payload,
+    interfaces::{
+        accounts::ProtocolAccount,
+        transactions::TransactionPayload
+    }
 };
 
 pub type WalletError = Box<dyn std::error::Error + Send>;

--- a/src/compute/contract/mod.rs
+++ b/src/compute/contract/mod.rs
@@ -4,6 +4,7 @@ pub use contract::*;
 
 use sha3::{Digest, Keccak256};
 use crate::{Address, Transaction};
+use crate::interfaces::transactions::ProtocolTransaction;
 
 pub fn create_program_id(content_id: String, transaction: &Transaction) -> Result<Address, Box<dyn std::error::Error + Send>> {
     let pubkey = transaction.sig().map_err(|e| {

--- a/src/compute/types.rs
+++ b/src/compute/types.rs
@@ -1,5 +1,19 @@
 use std::{collections::{HashMap, BTreeMap, hash_map::DefaultHasher}, hash::{Hash, Hasher}};
-use crate::{Address, TokenField, Transaction, Certificate, TokenWitness, TokenFieldValue, TransactionFields, Namespace, ProgramField, ProgramFieldValue, Account, DataValue};
+use crate::{
+    Address, 
+    TokenField, 
+    Transaction, 
+    Certificate, 
+    TokenWitness, 
+    TokenFieldValue, 
+    TransactionFields, 
+    Namespace, 
+    ProgramField, 
+    ProgramFieldValue, 
+    Account, 
+    DataValue,
+    interfaces::transactions::ProtocolTransaction
+};
 use schemars::JsonSchema;
 use serde::{Serialize, Deserialize};
 use serde_json::{Map, Value};

--- a/src/interfaces/accounts.rs
+++ b/src/interfaces/accounts.rs
@@ -1,0 +1,54 @@
+use crate::{
+    AccountType,
+    AddressOrNamespace,
+    Address,
+    ArbitraryData,
+    Metadata,
+    U256,
+    Transaction,
+    ProgramFieldValue,
+    TokenUpdateField,
+    ProgramUpdate
+};
+
+use std::collections::{BTreeMap, BTreeSet};
+
+pub trait ProtocolAccount {
+    type SendResult;
+    type ProgramUpdateResult;
+    type Token;
+    /// Constructs a new `Account` with the given address and optional program data.
+    ///
+    /// This function initializes an account with the provided address and an optional
+    /// map of programs. It updates the account hash before returning.
+    fn new(account_type: AccountType, program_namespace: Option<AddressOrNamespace>, owner_address: Address, _programs: Option<BTreeMap<Address, Self::Token>>) -> Self;
+    fn account_type(&self) -> AccountType;
+    fn program_namespace(&self) -> Option<AddressOrNamespace>; 
+    fn owner_address(&self) -> Address; 
+    fn nonce(&self) -> U256;
+    fn programs(&self) -> &BTreeMap<Address, Self::Token>;
+    fn programs_mut(&mut self) -> &mut BTreeMap<Address, Self::Token>; 
+    fn program_account_data(&self) -> &ArbitraryData;
+    fn program_account_data_mut(&mut self) -> &mut ArbitraryData;
+    fn program_account_metadata(&self) -> &Metadata;
+    fn program_account_metadat_mut(&mut self) -> &mut Metadata;
+    fn program_account_linked_programs(&self) -> &BTreeSet<AddressOrNamespace>;
+    fn program_account_linked_programs_mut(&mut self) -> &mut BTreeSet<AddressOrNamespace>;
+    fn balance(&self, program_id: &Address) -> U256; 
+    fn apply_send_transaction(&mut self, transaction: Transaction) -> Self::SendResult;
+    fn apply_transfer_to_instruction(&mut self, token_address: &Address, amount: &Option<U256>, token_ids: &Vec<U256>) -> Self::SendResult;
+    fn apply_transfer_from_instruction(&mut self, token_address: &Address, amount: &Option<U256>, token_ids: &Vec<U256>) -> Self::SendResult;
+    fn apply_burn_instruction(&mut self, token_address: &Address, amount: &Option<U256>, token_ids: &Vec<U256>) -> Self::SendResult;
+    fn apply_token_distribution(&mut self, program_id: &Address, amount: &Option<U256>, token_ids: &Vec<U256>, token_updates: &Vec<TokenUpdateField>) -> Self::SendResult; 
+    fn apply_token_update(&mut self, program_id: &Address, updates: &Vec<TokenUpdateField>) -> Self::SendResult; 
+    fn apply_program_update_field_values(&mut self, update_field_value: &ProgramFieldValue) -> Self::ProgramUpdateResult; 
+    fn apply_program_update(&mut self, update: &ProgramUpdate) -> Self::ProgramUpdateResult;
+    fn insert_program(&mut self, program_id: &Address, token: Self::Token) -> Option<Self::Token>;
+    fn validate_program_id(&self, program_id: &Address) -> Self::ProgramUpdateResult;
+    fn validate_balance(&self, program_id: &Address, amount: U256) -> Self::ProgramUpdateResult; 
+    fn validate_token_ownership(&self, program_id: &Address, token_ids: &Vec<U256>) -> Self::ProgramUpdateResult;
+    fn validate_approved_spend(&self, program_id: &Address, spender: &Address, amount: &U256) -> Self::ProgramUpdateResult;
+    fn validate_approved_token_transfer(&self, program_id: &Address, spender: &Address, token_ids: &Vec<crate::U256>) -> Self::ProgramUpdateResult;
+    fn validate_nonce(&self, nonce: crate::U256) -> Self::ProgramUpdateResult;
+    fn increment_nonce(&mut self);
+}

--- a/src/interfaces/mod.rs
+++ b/src/interfaces/mod.rs
@@ -1,0 +1,3 @@
+pub mod program_objects;
+pub mod transactions;
+pub mod accounts;

--- a/src/interfaces/program_objects.rs
+++ b/src/interfaces/program_objects.rs
@@ -1,0 +1,44 @@
+use std::collections::BTreeMap;
+use crate::{
+    U256,
+    DataValue,
+    TokenFieldValue,
+    MetadataValue,
+    ApprovalsValue,
+    AllowanceValue,
+    StatusValue,
+    Address,
+    ArbitraryData,
+    Metadata,
+    Status
+};
+
+pub trait ProgramObject {
+    fn debit(&mut self, amount: &U256) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn credit(&mut self, amount: &U256) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn remove_token_ids(&mut self, token_ids: &Vec<U256>) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn add_token_ids(&mut self, token_ids: &Vec<U256>) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn apply_token_update_field_values(&mut self, token_update_value: &TokenFieldValue) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn apply_data_update(&mut self, data_update: &DataValue) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn apply_metadata_update(&mut self, metadata_update: &MetadataValue) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn apply_approvals_update(&mut self, approvals_update: &ApprovalsValue) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn apply_allowance_update(&mut self, allowance_update: &AllowanceValue) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn apply_status_update(&mut self, status_update: &StatusValue) -> Result<(), Box<dyn std::error::Error + Send>>;
+    fn program_id(&self) -> Address;
+    fn owner_id(&self) -> Address;
+    fn balance(&self) -> U256;
+    fn balance_mut(&mut self) -> &mut U256;
+    fn metadata(&self) -> Metadata;
+    fn metadata_mut(&mut self) -> &mut Metadata;
+    fn token_ids(&self) -> Vec<U256>;
+    fn token_ids_mut(&mut self) -> &mut Vec<U256>;
+    fn allowance(&self) -> BTreeMap<Address, U256>;
+    fn allowance_mut(&mut self) -> &mut BTreeMap<Address, U256>;
+    fn approvals(&self) -> BTreeMap<Address, Vec<U256>>;
+    fn approvals_mut(&mut self) -> &mut BTreeMap<Address, Vec<U256>>;
+    fn data(&self) -> ArbitraryData;
+    fn data_mut(&mut self) -> &mut ArbitraryData;
+    fn status(&self) -> Status;
+    fn status_mut(&mut self) -> &mut Status;
+    fn update_balance(&mut self, receive: U256, send: U256);
+}

--- a/src/interfaces/transactions.rs
+++ b/src/interfaces/transactions.rs
@@ -1,0 +1,42 @@
+use crate::{
+    Address,
+    TransactionType,
+    RecoverableSignature,
+    U256
+};
+
+use secp256k1::{Error as Secp256k1Error, PublicKey};
+use std::error::Error;
+
+pub trait ProtocolTransaction {
+    fn program_id(&self) -> Address;
+    fn from(&self) -> Address; 
+    fn to(&self) -> Address; 
+    fn transaction_type(&self) -> TransactionType; 
+    fn op(&self) -> String; 
+    fn inputs(&self) -> String; 
+    fn value(&self) -> U256; 
+    fn nonce(&self) -> U256;
+    fn sig(&self) -> Result<RecoverableSignature, Box<dyn Error>>; 
+    fn recover(&self) -> Result<PublicKey, Box<dyn Error>>;
+    fn message(&self) -> String;
+    fn hash_string(&self) -> String;
+    fn hash(&self) -> Vec<u8>;
+    fn as_bytes(&self) -> Vec<u8>;
+    fn verify_signature(&self) -> Result<(), Secp256k1Error>; 
+    fn get_accounts_involved(&self) -> Vec<Address>; 
+}
+
+pub trait TransactionPayload {
+    fn transaction_type(&self) -> TransactionType; 
+    fn from(&self) -> [u8; 20]; 
+    fn to(&self) -> [u8; 20]; 
+    fn program_id(&self) -> [u8; 20]; 
+    fn op(&self) -> String; 
+    fn inputs(&self) -> String; 
+    fn value(&self) -> crate::U256; 
+    fn nonce(&self) -> crate::U256;
+    fn hash_string(&self) -> String; 
+    fn hash(&self) -> Vec<u8>; 
+    fn as_bytes(&self) -> Vec<u8>; 
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,9 @@ pub mod clients;
 pub mod token;
 pub mod transaction;
 pub mod compute;
+pub mod interfaces;
 
+pub use crate::interfaces::*;
 pub use crate::sequencer::*;
 pub use crate::account::*;
 pub use crate::program::*;

--- a/src/token.rs
+++ b/src/token.rs
@@ -7,7 +7,7 @@ use std::ops::{AddAssign, SubAssign};
 use schemars::JsonSchema;
 use uint::construct_uint;
 
-use crate::{Address, RecoverableSignature, Transaction};
+use crate::{Address, RecoverableSignature, Transaction, program_objects::ProgramObject};
 
 pub const TOKEN_WITNESS_VERSION: &'static str = "0.1.0";
 
@@ -248,8 +248,8 @@ pub struct Token {
     status: Status,
 }
 
-impl Token {
-    pub(crate) fn debit(&mut self, amount: &U256) -> Result<(), Box<dyn std::error::Error + Send>> {
+impl ProgramObject for Token {
+    fn debit(&mut self, amount: &U256) -> Result<(), Box<dyn std::error::Error + Send>> {
         if amount > &self.balance {
             return Err(
                 Box::new(
@@ -265,12 +265,12 @@ impl Token {
         return Ok(())
     }
 
-    pub(crate) fn credit(&mut self, amount: &U256) -> Result<(), Box<dyn std::error::Error + Send>> {
+    fn credit(&mut self, amount: &U256) -> Result<(), Box<dyn std::error::Error + Send>> {
         self.balance += *amount;
         return Ok(())
     }
 
-    pub(crate) fn remove_token_ids(&mut self, token_ids: &Vec<U256>) -> Result<(), Box<dyn std::error::Error + Send>> {
+    fn remove_token_ids(&mut self, token_ids: &Vec<U256>) -> Result<(), Box<dyn std::error::Error + Send>> {
         let positions: Vec<usize> = { 
             token_ids.iter().filter_map(|nft| {
                 self.token_ids.iter().position(|i| i == nft)
@@ -293,7 +293,7 @@ impl Token {
         Ok(())
     }
 
-    pub(crate) fn add_token_ids(
+    fn add_token_ids(
         &mut self, 
         token_ids: &Vec<U256>
     ) -> Result<(), Box<dyn std::error::Error + Send>> {
@@ -301,7 +301,7 @@ impl Token {
         Ok(())
     }
 
-    pub(crate) fn apply_token_update_field_values(
+    fn apply_token_update_field_values(
         &mut self,
         token_update_value: &TokenFieldValue
     ) -> Result<(), Box<dyn std::error::Error + Send>> {
@@ -456,6 +456,76 @@ impl Token {
         }
         Ok(())
     }
+
+    fn program_id(&self) -> Address {
+        self.program_id.clone()
+    }
+
+    fn owner_id(&self) -> Address {
+        self.owner_id.clone()
+    } 
+
+    fn balance(&self) -> U256 {
+        self.balance.clone()
+    }
+
+    fn balance_mut(&mut self) -> &mut U256 {
+        &mut self.balance
+    }
+
+    fn metadata(&self) -> Metadata {
+        self.metadata.clone()
+    }
+
+    fn metadata_mut(&mut self) -> &mut Metadata {
+        &mut self.metadata
+    }
+
+    fn token_ids(&self) -> Vec<U256> {
+        self.token_ids.clone()
+    }
+
+    fn token_ids_mut(&mut self) -> &mut Vec<U256> {
+        &mut self.token_ids
+    }
+
+    fn allowance(&self) -> BTreeMap<Address, U256> {
+        self.allowance.clone()
+    }
+
+    fn allowance_mut(&mut self) -> &mut BTreeMap<Address, U256> {
+        &mut self.allowance
+    }
+
+    fn approvals(&self) -> BTreeMap<Address, Vec<U256>> {
+        self.approvals.clone()
+    }
+
+    fn approvals_mut(&mut self) -> &mut BTreeMap<Address, Vec<U256>> {
+        &mut self.approvals
+    }
+
+    fn data(&self) -> ArbitraryData {
+        self.data.clone()
+    }
+
+    fn data_mut(&mut self) -> &mut ArbitraryData {
+        &mut self.data
+    }
+
+    fn status(&self) -> Status {
+        self.status.clone()
+    }
+
+    fn status_mut(&mut self) -> &mut Status {
+        &mut self.status
+    }
+
+    fn update_balance(&mut self, receive: U256, send: U256) {
+        self.balance += receive;
+        self.balance -= send;
+    }
+
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
Implement methods on types as traits so that they can be abstracted to rusty-lasr-sdk without losing functionality. 

This is part of a modularization effort so that the cli and other tools can also be abstracted out of the lasr crate and cross compiled.

At the end of this effort what will be left in the core lasr crate will be the Actors and the main binary, everything else will be abstracted away into separate crates and traits will be used to implement *Protocol Only* methods on them. 

This is an ongoing effort that will see the size of this codebase reduced significantly, leading to much greater maintainability and visibility into critical bugs/issues with the node runtime.

The goal is to make the node runtime client as resilient and fault tolerant as possible, while making the efforts needed to upgrade and add features and functionality to it as minimal as possible. This draft PR is a first stab at that effort.

This PR is still a WIP but is at a stable enough place to open a PR for it.