### PR TITLE
Set beta version number in Cargo.toml

### DIFF
--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_actors"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_cli"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/clients/Cargo.toml
+++ b/crates/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_clients"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_compute"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_contract"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_messages"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_node"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_rpc"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_types"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_wallet"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Setting version number for versatus repo and lasr repo to match beta release. Will tag main once merged unless there are other specific changes coming.