### PR TITLE
Add `ActorExt` & `Batcher::handle_transaction_error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,6 @@ dependencies = [
  "dotenv",
  "eigenda_client",
  "eo_listener",
- "futures",
  "jsonrpsee",
  "lasr_actors",
  "lasr_clients",

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -85,7 +85,7 @@ pub enum BatcherError {
 
 #[derive(Clone, Debug, Default)]
 pub struct BatcherActor {
-    pub future_pool: UnorderedFuturePool<StaticFuture<Result<(), BatcherError>>>,
+    future_pool: UnorderedFuturePool<StaticFuture<Result<(), BatcherError>>>,
 }
 impl BatcherActor {
     pub fn new() -> Self {

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -1818,11 +1818,12 @@ impl Actor for BatcherActor {
 }
 impl ActorExt for BatcherActor {
     type Output = Result<(), BatcherError>;
-    type FuturePool<O> = UnorderedFuturePool<StaticFuture<Self::Output>>;
+    type Future<O> = StaticFuture<Self::Output>;
+    type FuturePool<F> = UnorderedFuturePool<Self::Future<Self::Output>>;
     type FutureHandler = tokio_rayon::rayon::ThreadPool;
     type JoinHandle = tokio::task::JoinHandle<()>;
 
-    fn future_pool(&self) -> Self::FuturePool<Self::Output> {
+    fn future_pool(&self) -> Self::FuturePool<Self::Future<Self::Output>> {
         self.future_pool.clone()
     }
 

--- a/crates/actors/src/helpers.rs
+++ b/crates/actors/src/helpers.rs
@@ -25,21 +25,30 @@ pub type StaticFuture<O> = BoxFuture<'static, O>;
 /// `Actor::handle` to a `FuturePool` to be `await`ed at a later time,
 /// unblocking the `handle` method for that `Actor`.
 pub trait ActorExt: ractor::Actor {
-    /// Represents the `Output` from a `Future` (`Future<Output = T>`).
+    /// Represents the `Output` of a `Future` (`Future<Output = T>`).
     type Output;
-    /// This is intended to be either an `UnorderedFuturePool`, or
-    /// `OrderedFuturePool` containing some `StaticFuture`s.
+    /// The type of pool that will store forwarded `Future`s.
+    ///
+    /// Example:
+    /// ```rust,ignore
+    /// use lasr_actors::helpers::{OrderedFuturePool, StaticFuture, ActorExt};
+    ///
+    /// impl ActorExt for MyActor {
+    ///     type Output = ();
+    ///     type FuturePool<O> = OrderedFuturePool<StaticFuture<Self::Output>>;
+    ///     // ...
+    /// }
+    /// ```
     type FuturePool<O>;
-    /// The thread(s) that `await` `Future`s that are passed to it.
+    /// The thread(s) that will `await` `Future`s passed to it from `Self::FuturePool`.
     type FutureHandler;
-    /// The handle type of the thread responsible for passing `StaticFuture`s to
-    /// the `Self::FutureHandler` to be `await`ed.
+    /// The handle of the thread responsible for passing `Future`s to `Self::FutureHandler`.
     type JoinHandle;
 
     /// Returns a thread-safe, non-blocking mutatable future pool for polling
     /// futures in a future handler thread.
     ///
-    /// Note: If using `UnorderedFuturePool`, or `OrderedFuturePool` this will
+    /// > Note: If using `UnorderedFuturePool`, or `OrderedFuturePool` this will
     /// likely need to be an `Arc::clone`, incrementing the atomic reference
     /// count by 1.
     fn future_pool(&self) -> Self::FuturePool<Self::Output>;

--- a/crates/actors/src/helpers.rs
+++ b/crates/actors/src/helpers.rs
@@ -1,12 +1,52 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::{AccountCacheError, EngineError};
 use ethereum_types::H256;
+use futures::future::BoxFuture;
+use futures::stream::{FuturesOrdered, FuturesUnordered};
 use lasr_messages::{AccountCacheMessage, ActorType, DaClientMessage, EoMessage};
 use lasr_types::{Account, Address};
 use ractor::concurrency::{oneshot, OneshotReceiver};
 use ractor::ActorRef;
-use tokio::time::timeout;
+use tokio::{sync::Mutex, time::timeout};
+
+/// A thread-safe, non-blocking & mutatable `FuturesUnordered`.
+pub type UnorderedFuturePool<F> = Arc<Mutex<FuturesUnordered<F>>>;
+/// A thread-safe, non-blocking & mutatable `FuturesOrdered`.
+pub type OrderedFuturePool<F> = Arc<Mutex<FuturesOrdered<F>>>;
+/// Equivalent to `Pin<Box<dyn Future<Output = O> + Send + 'static>>`.
+///
+/// Shorthand for needing to specify the `'static` lifetime for `BoxFuture` all the time
+/// for types that house `Futures` that will be forwarded to a thread to be `await`ed`.
+pub type StaticFuture<O> = BoxFuture<'static, O>;
+
+/// An extension trait for `Actor`s that aids in forwarding `Future`s from
+/// `Actor::handle` to a `FuturePool` to be `await`ed at a later time,
+/// unblocking the `handle` method for that `Actor`.
+pub trait ActorExt: ractor::Actor {
+    /// Represents the `Output` from a `Future` (`Future<Output = T>`).
+    type Output;
+    /// This is intended to be either an `UnorderedFuturePool`, or
+    /// `OrderedFuturePool` containing some `StaticFuture`s.
+    type FuturePool<O>;
+    /// The thread(s) that `await` `Future`s that are passed to it.
+    type FutureHandler;
+    /// The handle type of the thread responsible for passing `StaticFuture`s to
+    /// the `Self::FutureHandler` to be `await`ed.
+    type JoinHandle;
+
+    /// Returns a thread-safe, non-blocking mutatable future pool for polling
+    /// futures in a future handler thread.
+    ///
+    /// Note: If using `UnorderedFuturePool`, or `OrderedFuturePool` this will
+    /// likely need to be an `Arc::clone`, incrementing the atomic reference
+    /// count by 1.
+    fn future_pool(&self) -> Self::FuturePool<Self::Output>;
+
+    /// Spawn a thread that passes futures to a thread pool to await them there.
+    fn spawn_future_handler(actor: Self, future_handler: Self::FutureHandler) -> Self::JoinHandle;
+}
 
 #[macro_export]
 macro_rules! create_handler {

--- a/crates/actors/src/helpers.rs
+++ b/crates/actors/src/helpers.rs
@@ -37,7 +37,8 @@ pub trait ActorExt: ractor::Actor {
     ///
     /// impl ActorExt for MyActor {
     ///     type Output = ();
-    ///     type FuturePool<O> = OrderedFuturePool<StaticFuture<Self::Output>>;
+    ///     type Future<O> = StaticFuture<Self::Output>;
+    ///     type FuturePool<F> = OrderedFuturePool<Self::Future<Self::Output>>;
     ///     // ...
     /// }
     /// ```

--- a/crates/actors/src/helpers.rs
+++ b/crates/actors/src/helpers.rs
@@ -27,6 +27,8 @@ pub type StaticFuture<O> = BoxFuture<'static, O>;
 pub trait ActorExt: ractor::Actor {
     /// Represents the `Output` of a `Future` (`Future<Output = T>`).
     type Output;
+    /// The type of `Future` to be forwarded by `Self::FuturePool`.
+    type Future<O>;
     /// The type of pool that will store forwarded `Future`s.
     ///
     /// Example:
@@ -39,7 +41,7 @@ pub trait ActorExt: ractor::Actor {
     ///     // ...
     /// }
     /// ```
-    type FuturePool<O>;
+    type FuturePool<F>;
     /// The thread(s) that will `await` `Future`s passed to it from `Self::FuturePool`.
     type FutureHandler;
     /// The handle of the thread responsible for passing `Future`s to `Self::FutureHandler`.
@@ -51,7 +53,7 @@ pub trait ActorExt: ractor::Actor {
     /// > Note: If using `UnorderedFuturePool`, or `OrderedFuturePool` this will
     /// likely need to be an `Arc::clone`, incrementing the atomic reference
     /// count by 1.
-    fn future_pool(&self) -> Self::FuturePool<Self::Output>;
+    fn future_pool(&self) -> Self::FuturePool<Self::Future<Self::Output>>;
 
     /// Spawn a thread that passes futures to a thread pool to await them there.
     fn spawn_future_handler(actor: Self, future_handler: Self::FutureHandler) -> Self::JoinHandle;

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -38,7 +38,6 @@ jsonrpsee = { version = "0.16.2", features = [
 eigenda_client = { git = "https://github.com/versatus/eigenda_client" }
 ractor = { version = "0.9.3", features = ["async-std", "cluster"] }
 eo_listener = { git = "https://github.com/versatus/eo_listener" }
-futures = "0.3.29"
 log = "0.4.20"
 simple_logger = "4.3.0"
 dotenv = "0.15.0"


### PR DESCRIPTION
Updates the `helpers` module with some convenience types and a trait extension for `ractor::Actor` to make integrating the new async design pattern easier for the other `Actor` types.

This implements the use of the aforementioned trait and types for the `BatcherActor` and fixes the error handling for failed transaction methods (prev `handle_batcher_error`)
- [x] `add_transaction_to_account`
- [x] `apply_instructions_to_accounts`
- [x] `apply_program_registration`

Ref #71 