### PR TITLE
Change hard-coded thread count to `num_cpus::get()`

### DIFF
--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -41,6 +41,7 @@ base64 = "0.13"
 flate2 = "1.0.28"
 async-recursion = "1.0.5"
 tokio-rayon = "2.1.0"
+num_cpus = "1.16.0"
 schemars = "0.8.16"
 chrono = "0.4.35"
 uuid = { version = "1.3", features = ["v4", "serde"] }
@@ -52,5 +53,4 @@ lasr_contract = { path = "../contract" }
 lasr_messages = { path = "../messages" }
 
 [dev-dependencies]
-num_cpus = "1.16.0"
 anyhow = "1"

--- a/crates/actors/src/validator.rs
+++ b/crates/actors/src/validator.rs
@@ -18,9 +18,9 @@ pub struct ValidatorCore {
 impl Default for ValidatorCore {
     fn default() -> Self {
         let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(50)
+            .num_threads(num_cpus::get())
             .build()
-            .unwrap();
+            .expect("failed to initialize rayon thread pool for validator core");
 
         Self { pool }
     }


### PR DESCRIPTION
Potential cause for the core dump being the thread count is initialized as a hard-coded 50 threads. This just changes it to use the number of logical cores instead. We should consider the overall overhead and potential consequences of using multiple `rayon::ThreadPool`s at runtime in general, but this will at least reduce the chance of things failing due to an uninitialized thread pool.

Ref #98 