### PR TITLE
Add `DaClientActor` to future handler

### DIFF
--- a/crates/actors/src/da_client.rs
+++ b/crates/actors/src/da_client.rs
@@ -1,6 +1,6 @@
-use std::{fmt::Display, time::Duration};
+use std::{fmt::Display, sync::Arc, time::Duration};
 
-use crate::Batch;
+use crate::{ActorExt, Batch, StaticFuture, UnorderedFuturePool};
 use async_trait::async_trait;
 use eigenda_client::{
     blob::EncodedBlob,
@@ -9,11 +9,97 @@ use eigenda_client::{
     response::BlobResponse,
     status::{BlobResult, BlobStatus},
 };
+use ethereum_types::H256;
+use futures::{
+    stream::{FuturesUnordered, StreamExt},
+    FutureExt,
+};
 use lasr_messages::DaClientMessage;
-use lasr_types::AccountType;
+use lasr_types::{Account, AccountType, Address};
 use ractor::{concurrency::OneshotSender, Actor, ActorProcessingErr, ActorRef, SupervisionEvent};
 use thiserror::Error;
-use tokio::task::JoinHandle;
+use tokio::{sync::Mutex, task::JoinHandle};
+
+#[derive(Clone, Debug, Default)]
+pub struct DaClientActor {
+    future_pool: UnorderedFuturePool<StaticFuture<Result<(), DaClientError>>>,
+}
+
+impl DaClientActor {
+    pub fn new() -> Self {
+        Self {
+            future_pool: Arc::new(Mutex::new(FuturesUnordered::new())),
+        }
+    }
+    async fn store_batch(
+        da_client: Arc<Mutex<DaClient>>,
+        batch: String,
+        tx: OneshotSender<Result<BlobResponse, std::io::Error>>,
+    ) -> Result<(), DaClientError> {
+        log::info!("DA Client asked to store blob");
+        let blob_response = {
+            let state = da_client.lock().await;
+            state.disperse_blobs(batch).await
+        };
+        let _ = tx.send(blob_response);
+        Ok(())
+    }
+    async fn validate_blob(
+        da_client: Arc<Mutex<DaClient>>,
+        request_id: String,
+        tx: OneshotSender<(String, BlobVerificationProof)>,
+    ) -> Result<(), DaClientError> {
+        log::info!("DA Client asked to validate blob");
+        let state = da_client.lock().await;
+        validate_blob(state.client.clone(), request_id, tx).await;
+        // Spawn a tokio task to poll EigenDa for the validated blob
+        Ok(())
+    }
+    async fn retrieve_account(
+        da_client: Arc<Mutex<DaClient>>,
+        address: Address,
+        batch_header_hash: H256,
+        blob_index: u128,
+        tx: OneshotSender<Option<Account>>,
+    ) -> Result<(), DaClientError> {
+        log::warn!("Received a RetrieveAccount message");
+        let batch_header_hash = base64::encode(batch_header_hash.0);
+        let res = {
+            let state = da_client.lock().await;
+            state
+                .client
+                .retrieve_blob(&batch_header_hash.into(), blob_index)
+        };
+        if let Ok(blob) = res {
+            let encoded_blob = EncodedBlob::from_str(&blob);
+            if let Ok(blob) = encoded_blob {
+                let res = Batch::decode_batch(&blob.data());
+                if let Ok(batch) = &res {
+                    let account = batch.get_user_account(address);
+                    let _ = tx
+                        .send(account.clone())
+                        .map_err(|e| DaClientError::Custom(format!("{:?}", e)))?;
+                    log::warn!("successfully decoded account blob");
+                    if let Some(acct) = account {
+                        if let AccountType::Program(addr) = acct.account_type() {
+                            log::warn!("found account: {}", addr.to_full_string());
+                        } else {
+                            log::warn!("found account: {}", acct.owner_address().to_full_string());
+                        }
+                    }
+                } else {
+                    log::error!("{:?}", res);
+                }
+            }
+        } else {
+            log::error!(
+                "Error attempting to retreive account: da_client.rs: Line 87: {:?}",
+                res
+            );
+        }
+        Ok(())
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct DaClient {
@@ -49,37 +135,38 @@ impl DaClient {
 }
 
 #[async_trait]
-impl Actor for DaClient {
+impl Actor for DaClientActor {
     type Msg = DaClientMessage;
-    type State = ();
-    type Arguments = ();
+    type State = Arc<Mutex<DaClient>>;
+    type Arguments = Self::State;
 
     async fn pre_start(
         &self,
         _myself: ActorRef<Self::Msg>,
-        _args: (),
+        args: Self::State,
     ) -> Result<Self::State, ActorProcessingErr> {
         log::info!("Da Client running prestart routine");
-        Ok(())
+        Ok(args)
     }
 
     async fn handle(
         &self,
         _myself: ActorRef<Self::Msg>,
         message: Self::Msg,
-        _state: &mut Self::State,
+        state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
+        let da_client_ptr = Arc::clone(state);
         match message {
             // Optimistically and naively store account blobs
             DaClientMessage::StoreBatch { batch, tx } => {
-                log::info!("DA Client asked to store blob");
-                let blob_response = self.disperse_blobs(batch).await;
-                let _ = tx.send(blob_response);
+                let fut = DaClientActor::store_batch(da_client_ptr, batch, tx);
+                let guard = self.future_pool.lock().await;
+                guard.push(fut.boxed());
             }
             DaClientMessage::ValidateBlob { request_id, tx } => {
-                log::info!("DA Client asked to validate blob");
-                validate_blob(self.client.clone(), request_id, tx).await;
-                // Spawn a tokio task to poll EigenDa for the validated blob
+                let fut = DaClientActor::validate_blob(da_client_ptr, request_id, tx);
+                let guard = self.future_pool.lock().await;
+                guard.push(fut.boxed());
             }
             // Optimistically and naively retreive account blobs
             DaClientMessage::RetrieveAccount {
@@ -88,47 +175,48 @@ impl Actor for DaClient {
                 blob_index,
                 tx,
             } => {
-                log::warn!("Received a RetrieveAccount message");
-                let batch_header_hash = base64::encode(batch_header_hash.0);
-                let res = self
-                    .client
-                    .retrieve_blob(&batch_header_hash.into(), blob_index);
-                if let Ok(blob) = res {
-                    let encoded_blob = EncodedBlob::from_str(&blob);
-                    if let Ok(blob) = encoded_blob {
-                        let res = Batch::decode_batch(&blob.data());
-                        if let Ok(batch) = &res {
-                            let account = batch.get_user_account(address);
-                            let _ = tx
-                                .send(account.clone())
-                                .map_err(|e| Box::new(DaClientError::Custom(format!("{:?}", e))))?;
-                            log::warn!("successfully decoded account blob");
-                            if let Some(acct) = account {
-                                if let AccountType::Program(addr) = acct.account_type() {
-                                    log::warn!("found account: {}", addr.to_full_string());
-                                } else {
-                                    log::warn!(
-                                        "found account: {}",
-                                        acct.owner_address().to_full_string()
-                                    );
-                                }
-                            }
-                        } else {
-                            log::error!("{:?}", res);
-                        }
-                    }
-                } else {
-                    log::error!(
-                        "Error attempting to retreive account: da_client.rs: Line 87: {:?}",
-                        res
-                    );
-                }
+                let fut = DaClientActor::retrieve_account(
+                    da_client_ptr,
+                    address,
+                    batch_header_hash,
+                    blob_index,
+                    tx,
+                );
+                let guard = self.future_pool.lock().await;
+                guard.push(fut.boxed());
             }
             DaClientMessage::RetrieveTransaction { .. } => {}
             DaClientMessage::RetrieveContract { .. } => {}
             _ => {}
         }
-        return Ok(());
+        Ok(())
+    }
+}
+
+impl ActorExt for DaClientActor {
+    type Output = Result<(), DaClientError>;
+    type Future<O> = StaticFuture<Self::Output>;
+    type FuturePool<F> = UnorderedFuturePool<Self::Future<Self::Output>>;
+    type FutureHandler = tokio_rayon::rayon::ThreadPool;
+    type JoinHandle = tokio::task::JoinHandle<()>;
+
+    fn future_pool(&self) -> Self::FuturePool<Self::Future<Self::Output>> {
+        self.future_pool.clone()
+    }
+    fn spawn_future_handler(actor: Self, future_handler: Self::FutureHandler) -> Self::JoinHandle {
+        tokio::spawn(async move {
+            loop {
+                let futures = actor.future_pool();
+                let mut guard = futures.lock().await;
+                future_handler
+                    .install(|| async move {
+                        if let Some(Err(err)) = guard.next().await {
+                            log::error!("{err:?}");
+                        }
+                    })
+                    .await;
+            }
+        })
     }
 }
 

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -17,6 +17,7 @@ use lasr_actors::BatcherActor;
 use lasr_actors::BatcherError;
 use lasr_actors::BlobCacheActor;
 use lasr_actors::DaClient;
+use lasr_actors::DaClientActor;
 use lasr_actors::DaSupervisor;
 use lasr_actors::Engine;
 use lasr_actors::EoServer;
@@ -135,7 +136,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eo_client_actor = EoClientActor;
     let da_supervisor = DaSupervisor;
     let account_cache_supervisor = AccountCacheSupervisor;
-    let da_client_actor = DaClient::new(eigen_da_client);
+    let da_client_actor = DaClientActor::new();
     let batcher_actor = BatcherActor::new();
     let executor_actor = ExecutorActor::new();
     let inner_eo_server =
@@ -145,6 +146,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
 
     tokio::spawn(Batcher::run_receivers(receivers_thread_rx));
+
+    let da_client = Arc::new(Mutex::new(DaClient::new(eigen_da_client)));
 
     let (da_supervisor, _da_supervisor_handle) =
         Actor::spawn(Some("da_supervisor".to_string()), da_supervisor, ())
@@ -194,8 +197,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (_da_client_actor_ref, _da_client_handle) = Actor::spawn_linked(
         Some(ActorType::DaClient.to_string()),
-        da_client_actor,
-        (),
+        da_client_actor.clone(),
+        da_client,
         da_supervisor.get_cell(),
     )
     .await
@@ -282,6 +285,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let mut guard = futures.lock().await;
                 future_thread_pool
                     .install(|| async move { guard.next().await })
+                    .await;
+            }
+            {
+                let futures = da_client_actor.future_pool();
+                let mut guard = futures.lock().await;
+                future_thread_pool
+                    .install(|| async move {
+                        if let Some(Err(err)) = guard.next().await {
+                            log::error!("{err:?}");
+                        }
+                    })
                     .await;
             }
         }


### PR DESCRIPTION
Ref #71 

Refactor to the `ractor::Actor` impl for `DaClient`: Adds a `DaClientActor` type as the `Actor`, and uses `DaClient` as the `ractor::Actor::State`. Abstracts the message logic into associated functions on the `DaClientActor`. Implements `ActorExt` for `DaClientActor`. 