### PR TITLE
Remove unnecessary async await points in `EoServerActor`

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -19,7 +19,7 @@ use lasr_actors::BlobCacheActor;
 use lasr_actors::DaClient;
 use lasr_actors::DaSupervisor;
 use lasr_actors::Engine;
-use lasr_actors::EoServer;
+use lasr_actors::EoServerActor;
 use lasr_actors::EoServerWrapper;
 use lasr_actors::ExecutionEngine;
 use lasr_actors::ExecutorActor;
@@ -131,7 +131,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let scheduler_actor = TaskScheduler::new();
     let engine_actor = Engine::new();
     let validator_actor = Validator::new();
-    let eo_server_actor = EoServer::new();
+    let eo_server_actor = EoServerActor::new();
     let eo_client_actor = EoClientActor;
     let da_supervisor = DaSupervisor;
     let account_cache_supervisor = AccountCacheSupervisor;


### PR DESCRIPTION
Ref #71 

While refactoring the `EoServer` to be added to the future handler, I realized the `async` functions that are called are unnecessary. This refactor just renames `EoServer` to `EoServerActor` and removes the unused async await points from the `ractor::Actor::handle` method. It also refactors methods that take `self` but do not use `self` into associated functions.