### PR TITLE
Add extra logs for `eo_server::run`

### DIFF
--- a/crates/actors/src/eo_server.rs
+++ b/crates/actors/src/eo_server.rs
@@ -45,11 +45,13 @@ impl EoServerWrapper {
                 ))?
                 .into();
 
+        log::info!("attempting to load processed blocks");
         if let Err(e) = self.server.load_processed_blocks().await {
             log::error!("unable to load processed blocks from file: {}", e);
         }
 
         loop {
+            log::info!("EO Actor running");
             let logs = self.server.next().await;
             if let Ok(log) = &logs.log_result {
                 if !log.is_empty() {

--- a/crates/actors/src/eo_server.rs
+++ b/crates/actors/src/eo_server.rs
@@ -51,20 +51,22 @@ impl EoServerWrapper {
         }
 
         loop {
-            log::info!("EO Actor running");
             let logs = self.server.next().await;
-            if let Ok(log) = &logs.log_result {
-                if !log.is_empty() {
-                    log::info!("non-empty log found: {:?}", log);
-                    eo_actor
-                        .cast(EoMessage::Log {
-                            log_type: logs.event_type,
-                            log: log.to_vec(),
-                        })
-                        .map_err(|e| EoServerError::Custom(e.to_string()))?;
+            match &logs.log_result {
+                Ok(log) => {
+                    if !log.is_empty() {
+                        log::info!("non-empty log found: {:?}", log);
+                        eo_actor
+                            .cast(EoMessage::Log {
+                                log_type: logs.event_type,
+                                log: log.to_vec(),
+                            })
+                            .map_err(|e| EoServerError::Custom(e.to_string()))?;
 
-                    self.server.save_blocks_processed();
+                        self.server.save_blocks_processed();
+                    }
                 }
+                Err(e) => log::error!("EoServer Error: server log returned an error: {e:?}"),
             }
 
             if let ActorStatus::Stopped = eo_actor.get_status() {


### PR DESCRIPTION
Adding logs to see what response if any we get from Kaleido.