### PR TITLE
Add read hooks for persistence layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,6 +2823,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tikv-client",
  "tokio",
  "uuid",
  "web3",

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -124,14 +124,14 @@ pub struct Batch {
 // Structure for persistence layer `Account` values
 #[derive(Debug, Hash, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AccountValue {
-    account: Account,
+    pub account: Account,
 }
 
-// Structure for persistence layer `Transaction` values
-#[derive(Debug, Hash, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TransactionValue {
-    transaction: Transaction,
-}
+// // Structure for persistence layer `Transaction` values
+// #[derive(Debug, Hash, Clone, Serialize, Deserialize, PartialEq, Eq)]
+// pub struct TransactionValue {
+//     transaction: Transaction,
+// }
 
 impl Batch {
     pub fn new() -> Self {

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -2039,6 +2039,7 @@ pub async fn batch_requestor(
 mod batcher_tests {
     use crate::batcher::{ActorExt, Batcher, BatcherActor, BatcherMessage};
     use anyhow::Result;
+    use eigenda_client::proof::BlobVerificationProof;
     use futures::{FutureExt, StreamExt};
     use lasr_types::TransactionType;
     use std::sync::Arc;
@@ -2117,10 +2118,17 @@ mod batcher_tests {
         let batcher_actor = BatcherActor::new();
         let (receivers_thread_tx, receivers_thread_rx) = tokio::sync::mpsc::channel(128);
         let mut batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
-        let tikv_client = TikvClient::new(vec!["127.0.0.1:2379"]).await.unwrap();
+        let bv_proof = BlobVerificationProof::default();
+        let request = "test".to_string();
 
         batcher_actor
-            .handle(BatcherMessage::GetNextBatch { tikv_client }, &mut batcher)
+            .handle(
+                BatcherMessage::BlobVerificationProof {
+                    request_id: request,
+                    proof: bv_proof,
+                },
+                &mut batcher,
+            )
             .await
             .unwrap();
         // TODO: Add other handle methods to test interactions

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -29,7 +29,7 @@ use serde_json::Value;
 use sha3::{Digest, Keccak256};
 use std::io::Write;
 use thiserror::Error;
-use tikv_client::RawClient;
+use tikv_client::RawClient as TikvClient;
 use tokio::{
     sync::{
         mpsc::{Receiver, Sender, UnboundedSender},
@@ -1656,67 +1656,63 @@ impl Batcher {
         });
     }
 
-    async fn handle_next_batch_request(batcher: Arc<Mutex<Batcher>>) -> Result<(), BatcherError> {
+    async fn handle_next_batch_request(
+        batcher: Arc<Mutex<Batcher>>,
+        tikv_client: TikvClient,
+    ) -> Result<(), BatcherError> {
         if let Some(blob_response) = {
             let mut guard = batcher.lock().await;
             if !guard.parent.empty() {
                 log::info!("found next batch: {:?}", guard.parent);
 
-                // todo: set pd_endpoints to be env var
-                if let Ok(client) = RawClient::new(vec!["127.0.0.1:2379"]).await {
-                    log::info!("Connected to persistence layer successfully.");
+                if let Some(batch) = guard.parent.to_owned().into() {
+                    let account_map = &guard.parent.accounts;
+                    log::info!("{account_map:?}");
+                    // let transaction_map = &guard.parent.transactions;
 
-                    if let Some(batch) = guard.parent.to_owned().into() {
-                        let account_map = &guard.parent.accounts;
-                        log::info!("{account_map:?}");
-                        // let transaction_map = &guard.parent.transactions;
+                    while let Some((addr, account)) = account_map.iter().next() {
+                        let data = account.clone();
+                        //note: this can be serialized as well need be.
+                        //TiKV will accept any key if of type String, OR Vec<u8>
 
-                        while let Some((addr, account)) = account_map.iter().next() {
-                            let data = account.clone();
-                            //note: this can be serialized as well need be.
-                            //TiKV will accept any key if of type String, OR Vec<u8>
+                        let acc_val = AccountValue { account: data };
 
-                            let acc_val = AccountValue { account: data };
-
-                            // Serialize `Account` data to be stored.
-                            if let Some(val) = bincode::serialize(&acc_val).ok() {
-                                if client.put(addr.clone(), val).await.is_ok() {
-                                    log::info!("Inserted Account with address of {}", addr)
-                                } else {
-                                    log::error!("failed to push Account data to persistence store")
-                                }
+                        // Serialize `Account` data to be stored.
+                        if let Some(val) = bincode::serialize(&acc_val).ok() {
+                            if tikv_client.put(addr.clone(), val).await.is_ok() {
+                                log::info!("Inserted Account with address of {}", addr)
                             } else {
-                                log::error!("failed to serialize account data")
+                                log::error!("failed to push Account data to persistence store")
                             }
+                        } else {
+                            log::error!("failed to serialize account data")
                         }
-
-                        // while let Some(transaction) = transaction_map.iter().next() {
-                        //     let data = transaction.1.clone();
-                        //     if let Some(txn_sig) = data.sig().ok() {
-                        //         log::info!("Recoverable signature obtained.");
-
-                        //         // note: this can be serialized as well need be
-                        //         let txn_key = txn_sig.to_vec();
-
-                        //         let txn_val = TransactionValue { transaction: data };
-
-                        //         // Serialize `Transaction` data to be stored.
-                        //         if let Some(val) = bincode::serialize(&txn_val).ok() {
-                        //             if let Ok(txn_key) = client.put(txn_key, val).await {
-                        //                 log::info!("Inserted Txn with signature: {:?}", txn_key)
-                        //             } else {
-                        //                 log::error!("failed to push Txn data to persistence store.")
-                        //             }
-                        //         } else {
-                        //             log::error!("failed to serialize txn data")
-                        //         }
-                        //     } else {
-                        //         log::error!("failed to obtain recoverable signature")
-                        //     }
-                        // }
                     }
-                } else {
-                    log::error!("failed to connect to persistence store")
+
+                    // while let Some(transaction) = transaction_map.iter().next() {
+                    //     let data = transaction.1.clone();
+                    //     if let Some(txn_sig) = data.sig().ok() {
+                    //         log::info!("Recoverable signature obtained.");
+
+                    //         // note: this can be serialized as well need be
+                    //         let txn_key = txn_sig.to_vec();
+
+                    //         let txn_val = TransactionValue { transaction: data };
+
+                    //         // Serialize `Transaction` data to be stored.
+                    //         if let Some(val) = bincode::serialize(&txn_val).ok() {
+                    //             if let Ok(txn_key) = client.put(txn_key, val).await {
+                    //                 log::info!("Inserted Txn with signature: {:?}", txn_key)
+                    //             } else {
+                    //                 log::error!("failed to push Txn data to persistence store.")
+                    //             }
+                    //         } else {
+                    //             log::error!("failed to serialize txn data")
+                    //         }
+                    //     } else {
+                    //         log::error!("failed to obtain recoverable signature")
+                    //     }
+                    // }
                 }
 
                 if let Some(da_client) =
@@ -1862,8 +1858,8 @@ impl Actor for BatcherActor {
     ) -> Result<(), ActorProcessingErr> {
         let batcher_ptr = Arc::clone(state);
         match message {
-            BatcherMessage::GetNextBatch => {
-                Batcher::handle_next_batch_request(batcher_ptr).await?;
+            BatcherMessage::GetNextBatch { tikv_client } => {
+                Batcher::handle_next_batch_request(batcher_ptr, tikv_client).await?;
                 // let mut guard = self.future_pool.lock().await;
                 // guard.push(fut.boxed());
             }
@@ -2010,7 +2006,10 @@ impl Actor for BatcherSupervisor {
     }
 }
 
-pub async fn batch_requestor(mut stopper: tokio::sync::mpsc::Receiver<u8>) {
+pub async fn batch_requestor(
+    mut stopper: tokio::sync::mpsc::Receiver<u8>,
+    tikv_client: TikvClient,
+) {
     if let Some(batcher) = ractor::registry::where_is(ActorType::Batcher.to_string()) {
         let batcher: ActorRef<BatcherMessage> = batcher.into();
         let batch_interval_secs = std::env::var("BATCH_INTERVAL")
@@ -2020,7 +2019,9 @@ pub async fn batch_requestor(mut stopper: tokio::sync::mpsc::Receiver<u8>) {
         loop {
             log::info!("SLEEPING THEN REQUESTING NEXT BATCH");
             tokio::time::sleep(tokio::time::Duration::from_secs(batch_interval_secs)).await;
-            let message = BatcherMessage::GetNextBatch;
+            let message = BatcherMessage::GetNextBatch {
+                tikv_client: tikv_client.clone(),
+            };
             log::warn!("requesting next batch");
             if let Err(err) = batcher.cast(message) {
                 log::error!("Batcher Error: failed to cast GetNextBatch message to the BatcherActor during batch_requestor routine: {err:?}");
@@ -2043,6 +2044,7 @@ mod batcher_tests {
     use futures::{FutureExt, StreamExt};
     use lasr_types::TransactionType;
     use std::sync::Arc;
+    use tikv_client::RawClient as TikvClient;
     use tokio::sync::Mutex;
 
     /// Minimal reproduction of the `ractor::Actor` trait for testing the `handle`
@@ -2059,8 +2061,8 @@ mod batcher_tests {
         async fn handle(&self, message: Self::Msg, state: &mut Self::State) -> Result<()> {
             let batcher_ptr = Arc::clone(state);
             match message {
-                BatcherMessage::GetNextBatch => {
-                    let fut = Batcher::handle_next_batch_request(batcher_ptr);
+                BatcherMessage::GetNextBatch { tikv_client } => {
+                    let fut = Batcher::handle_next_batch_request(batcher_ptr, tikv_client);
                     let mut guard = self.future_pool.lock().await;
                     guard.push(fut.boxed());
                 }
@@ -2117,9 +2119,10 @@ mod batcher_tests {
         let batcher_actor = BatcherActor::new();
         let (receivers_thread_tx, receivers_thread_rx) = tokio::sync::mpsc::channel(128);
         let mut batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
+        let tikv_client = TikvClient::new(vec!["127.0.0.1:2379"]).await.unwrap();
 
         batcher_actor
-            .handle(BatcherMessage::GetNextBatch, &mut batcher)
+            .handle(BatcherMessage::GetNextBatch { tikv_client }, &mut batcher)
             .await
             .unwrap();
         // TODO: Add other handle methods to test interactions

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -316,7 +316,6 @@ impl Batch {
     }
 }
 
-#[derive(Debug)]
 pub struct Batcher {
     parent: Batch,
     children: VecDeque<Batch>,

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 uuid = { version = "1.3", features = ["v4", "serde"] }
 web3 = { version = "0.19.0" }
+tikv-client = "0.3.0"
 tokio = { version = "1.34.0", features = ["full"] }
 ractor = { version = "0.9.3", features = ["async-std", "cluster"] }
 ractor_cluster_derive = "0.9.3"

--- a/crates/messages/src/messages.rs
+++ b/crates/messages/src/messages.rs
@@ -12,6 +12,7 @@ use ractor::RpcReplyPort;
 use ractor_cluster::RactorMessage;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
+use tikv_client::RawClient as TikvClient;
 use web3::ethabi::{Address as EthereumAddress, FixedBytes};
 use web3::types::TransactionReceipt;
 
@@ -447,13 +448,15 @@ pub enum PendingTransactionMessage {
     CleanGraph,
 }
 
-#[derive(Debug, RactorMessage)]
+#[derive(RactorMessage)]
 pub enum BatcherMessage {
     AppendTransaction {
         transaction: Transaction,
         outputs: Option<Outputs>,
     },
-    GetNextBatch,
+    GetNextBatch {
+        tikv_client: TikvClient,
+    },
     BlobVerificationProof {
         request_id: String,
         proof: BlobVerificationProof,

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -274,6 +274,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let batcher_clone = batcher.clone();
     let executor_actor_clone = executor_actor.clone();
     let execution_engine_clone = execution_engine.clone();
+    let tikv_client_clone = tikv_client.clone();
 
     tokio::spawn(async move {
         while let Some(actor) = panic_rx.recv().await {
@@ -296,7 +297,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 manager_ptr,
                                 actor_name,
                                 account_cache_actor.clone(),
-                                tikv_client.clone(),
+                                tikv_client_clone.clone(),
                             )
                             .await
                             .typecast()
@@ -428,7 +429,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tokio::spawn(graph_cleaner());
     tokio::spawn(eo_server_wrapper.run());
     tokio::spawn(server_handle.stopped());
-    tokio::spawn(lasr_actors::batch_requestor(stop_rx));
+    tokio::spawn(lasr_actors::batch_requestor(stop_rx, tikv_client.clone()));
 
     let future_thread_pool = tokio_rayon::rayon::ThreadPoolBuilder::new()
         .num_threads(num_cpus::get())


### PR DESCRIPTION
Closes #169 
Closes #171 
Adds persistence read hooks to `account_cache`'s `handle()`
Abstracts client into `main()`
Creates an `inner` structure for `AccountCache`, which enables the actor to accept `tikv_client` while still deriving `Debug, Default`