### PR TITLE
Bump `jsonrpsee` version & Server connection limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,10 +2395,10 @@ dependencies = [
 [[package]]
 name = "internal_rpc"
 version = "0.9.0"
-source = "git+https://github.com/versatus/versatus.git#ef8475acbc905d4a48679330f4bb346c12fe07e5"
+source = "git+https://github.com/versatus/versatus.git?branch=andrewvious/797#23c6eef5e806804bbd87ea533d0b03a7862953d0"
 dependencies = [
  "anyhow",
- "jsonrpsee 0.16.3",
+ "jsonrpsee 0.22.5",
  "log",
  "platform",
  "serde",
@@ -2406,7 +2406,7 @@ dependencies = [
  "service_config",
  "tokio",
  "uuid",
- "web3_pkg",
+ "web3_pkg 0.9.0 (git+https://github.com/versatus/versatus.git?branch=andrewvious/797)",
 ]
 
 [[package]]
@@ -2972,7 +2972,7 @@ dependencies = [
  "tokio",
  "uint",
  "walkdir",
- "web3_pkg",
+ "web3_pkg 0.9.0 (git+https://github.com/versatus/versatus.git)",
 ]
 
 [[package]]
@@ -2997,7 +2997,7 @@ dependencies = [
  "tokio",
  "toml 0.8.12",
  "walkdir",
- "web3_pkg",
+ "web3_pkg 0.9.0 (git+https://github.com/versatus/versatus.git)",
 ]
 
 [[package]]
@@ -3058,7 +3058,7 @@ dependencies = [
  "tokio-rayon",
  "tokio-stream",
  "web3",
- "web3_pkg",
+ "web3_pkg 0.9.0 (git+https://github.com/versatus/versatus.git)",
 ]
 
 [[package]]
@@ -3676,7 +3676,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 [[package]]
 name = "platform"
 version = "0.9.0"
-source = "git+https://github.com/versatus/versatus.git#ef8475acbc905d4a48679330f4bb346c12fe07e5"
+source = "git+https://github.com/versatus/versatus.git?branch=andrewvious/797#23c6eef5e806804bbd87ea533d0b03a7862953d0"
 dependencies = [
  "anyhow",
  "bitmask-enum",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "service_config"
 version = "0.9.0"
-source = "git+https://github.com/versatus/versatus.git#ef8475acbc905d4a48679330f4bb346c12fe07e5"
+source = "git+https://github.com/versatus/versatus.git?branch=andrewvious/797#23c6eef5e806804bbd87ea533d0b03a7862953d0"
 dependencies = [
  "anyhow",
  "serde",
@@ -5856,6 +5856,25 @@ dependencies = [
  "hex",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "web3_pkg"
+version = "0.9.0"
+source = "git+https://github.com/versatus/versatus.git?branch=andrewvious/797#23c6eef5e806804bbd87ea533d0b03a7862953d0"
+dependencies = [
+ "anyhow",
+ "clap 3.2.25",
+ "derive_builder 0.12.0",
+ "futures",
+ "http 0.2.12",
+ "ipfs-api",
+ "ipfs-api-backend-hyper",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tokio",
+ "trust-dns-resolver",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,7 +1334,7 @@ dependencies = [
  "derive_builder 0.12.0",
  "futures",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "ractor",
  "rustc-hex",
@@ -1744,6 +1744,10 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -1834,6 +1838,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-net"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http 0.2.12",
+ "js-sys",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,6 +1868,19 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2162,10 +2200,10 @@ dependencies = [
  "hyper 0.14.28",
  "log",
  "rustls 0.21.12",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -2360,7 +2398,7 @@ version = "0.9.0"
 source = "git+https://github.com/versatus/versatus.git#ef8475acbc905d4a48679330f4bb346c12fe07e5"
 dependencies = [
  "anyhow",
- "jsonrpsee",
+ "jsonrpsee 0.16.3",
  "log",
  "platform",
  "serde",
@@ -2527,12 +2565,30 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "367a292944c07385839818bb71c8d76611138e2dedb0677d035b8da21d29c78b"
 dependencies = [
- "jsonrpsee-core",
- "jsonrpsee-http-client",
- "jsonrpsee-proc-macros",
- "jsonrpsee-server",
- "jsonrpsee-types",
- "jsonrpsee-ws-client",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-http-client 0.16.3",
+ "jsonrpsee-proc-macros 0.16.3",
+ "jsonrpsee-server 0.16.3",
+ "jsonrpsee-types 0.16.3",
+ "jsonrpsee-ws-client 0.16.3",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
+dependencies = [
+ "jsonrpsee-client-transport 0.22.5",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-http-client 0.22.5",
+ "jsonrpsee-proc-macros 0.22.5",
+ "jsonrpsee-server 0.22.5",
+ "jsonrpsee-types 0.22.5",
+ "jsonrpsee-wasm-client",
+ "jsonrpsee-ws-client 0.22.5",
+ "tokio",
  "tracing",
 ]
 
@@ -2544,17 +2600,41 @@ checksum = "c8b3815d9f5d5de348e5f162b316dc9cdf4548305ebb15b4eb9328e66cf27d7a"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-types 0.16.3",
  "pin-project",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "soketto",
  "thiserror",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.25.4",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "gloo-net",
+ "http 0.2.12",
+ "jsonrpsee-core 0.22.5",
+ "pin-project",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "soketto",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.25.0",
+ "tokio-util",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.1",
 ]
 
 [[package]]
@@ -2573,7 +2653,7 @@ dependencies = [
  "futures-util",
  "globset",
  "hyper 0.14.28",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.16.3",
  "parking_lot",
  "rand 0.8.5",
  "rustc-hash",
@@ -2586,6 +2666,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-core"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b257e1ec385e07b0255dde0b933f948b5c8b8c28d42afda9587c3a967b896d"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "beef",
+ "futures-timer",
+ "futures-util",
+ "hyper 0.14.28",
+ "jsonrpsee-types 0.22.5",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.5",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "jsonrpsee-http-client"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,14 +2700,34 @@ dependencies = [
  "async-trait",
  "hyper 0.14.28",
  "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-types 0.16.3",
  "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-http-client"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ccf93fc4a0bfe05d851d37d7c32b7f370fe94336b52a2f0efc5f1981895c2e5"
+dependencies = [
+ "async-trait",
+ "hyper 0.14.28",
+ "hyper-rustls",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -2618,6 +2744,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-proc-macros"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0bb047e79a143b32ea03974a6bf59b62c2a4c5f5d42a381c907a8bbb3f75c0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "jsonrpsee-server"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,11 +2766,35 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.28",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-types 0.16.3",
  "serde",
  "serde_json",
  "soketto",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-server"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d8b6a9674422a8572e0b0abb12feeb3f2aeda86528c80d0350c2bd0923ab41"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
+ "pin-project",
+ "route-recognizer",
+ "serde",
+ "serde_json",
+ "soketto",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2654,15 +2817,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpsee-types"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150d6168405890a7a3231a3c74843f58b8959471f6df76078db2619ddee1d07d"
+dependencies = [
+ "anyhow",
+ "beef",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonrpsee-wasm-client"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f448d8eacd945cc17b6c0b42c361531ca36a962ee186342a97cdb8fca679cd77"
+dependencies = [
+ "jsonrpsee-client-transport 0.22.5",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
+]
+
+[[package]]
 name = "jsonrpsee-ws-client"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e1b3975ed5d73f456478681a417128597acd6a2487855fdb7b4a3d4d195bf5e"
 dependencies = [
  "http 0.2.12",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-client-transport 0.16.3",
+ "jsonrpsee-core 0.16.3",
+ "jsonrpsee-types 0.16.3",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.22.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b9db2dfd5bb1194b0ce921504df9ceae210a345bc2f6c5a61432089bbab070"
+dependencies = [
+ "http 0.2.12",
+ "jsonrpsee-client-transport 0.22.5",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
+ "url",
 ]
 
 [[package]]
@@ -2724,7 +2924,7 @@ dependencies = [
  "futures",
  "hex",
  "internal_rpc",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "kzgpad-rs",
  "lasr_compute",
  "lasr_contract",
@@ -2761,7 +2961,7 @@ dependencies = [
  "clap 4.5.4",
  "ethereum-types 0.14.1",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "lasr_compute",
  "lasr_rpc",
  "lasr_types",
@@ -2816,6 +3016,7 @@ dependencies = [
  "eigenda_client",
  "eo_listener",
  "ethereum-types 0.14.1",
+ "jsonrpsee 0.22.5",
  "lasr_types",
  "ractor",
  "ractor_cluster",
@@ -2838,7 +3039,7 @@ dependencies = [
  "eigenda_client",
  "eo_listener",
  "futures",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "lasr_actors",
  "lasr_compute",
  "lasr_messages",
@@ -2864,7 +3065,7 @@ dependencies = [
 name = "lasr_rpc"
 version = "0.9.0"
 dependencies = [
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "lasr_types",
 ]
 
@@ -4162,6 +4363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4229,6 +4436,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afabcee0551bd1aa3e18e5adbf2c0544722014b899adb31bd186ec638d3da97e"
@@ -4250,6 +4471,19 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -4476,6 +4710,12 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "serde"
@@ -5028,6 +5268,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
@@ -5046,6 +5297,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5630,6 +5882,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -17,7 +17,7 @@ tikv-client = "0.3.0"
 tokio = { version = "1.34.0", features = ["full"] }
 futures = "0.3.29"
 async-trait = "0.1.74"
-jsonrpsee = { version = "0.16.2", features = [
+jsonrpsee = { version = "0.22.5", features = [
   "macros",
   "client-core",
   "server-core",

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -46,7 +46,7 @@ num_cpus = "1.16.0"
 schemars = "0.8.16"
 chrono = "0.4.35"
 uuid = { version = "1.3", features = ["v4", "serde"] }
-internal_rpc = { git = "https://github.com/versatus/versatus.git" }
+internal_rpc = { git = "https://github.com/versatus/versatus.git", branch = "andrewvious/797"}
 lasr_types = { path = "../types" }
 lasr_rpc = { path = "../rpc" }
 lasr_compute = { path = "../compute" }

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -46,7 +46,7 @@ num_cpus = "1.16.0"
 schemars = "0.8.16"
 chrono = "0.4.35"
 uuid = { version = "1.3", features = ["v4", "serde"] }
-internal_rpc = { git = "https://github.com/versatus/versatus.git", branch = "andrewvious/797"}
+internal_rpc = { git = "https://github.com/versatus/versatus.git" }
 lasr_types = { path = "../types" }
 lasr_rpc = { path = "../rpc" }
 lasr_compute = { path = "../compute" }

--- a/crates/actors/src/engine.rs
+++ b/crates/actors/src/engine.rs
@@ -29,7 +29,7 @@ use serde_json::Value;
 use sha3::{Digest, Keccak256};
 use thiserror::Error;
 
-use jsonrpsee::{core::Error as RpcError, tracing::trace_span};
+use jsonrpsee::{tracing::trace_span, types::ErrorObjectOwned as RpcError};
 use lasr_types::{
     Account, AccountType, Address, AddressOrNamespace, ArbitraryData, Metadata, Outputs,
     RecoverableSignature, Status, Token, TokenBuilder, Transaction, TransactionBuilder,

--- a/crates/actors/src/eo_server.rs
+++ b/crates/actors/src/eo_server.rs
@@ -10,7 +10,7 @@ use futures::{
     stream::{FuturesUnordered, StreamExt},
     FutureExt,
 };
-use jsonrpsee::core::Error as RpcError;
+use jsonrpsee::types::ErrorObjectOwned as RpcError;
 use lasr_types::{Account, Address, Token};
 use ractor::{
     concurrency::{oneshot, OneshotSender},

--- a/crates/actors/src/helpers.rs
+++ b/crates/actors/src/helpers.rs
@@ -171,14 +171,18 @@ macro_rules! create_handler {
             RpcMessage::Response { response, .. } => match response {
                 Ok(resp) => return Ok(resp),
                 _ => {
-                    return Err(Box::new(RpcError::Custom(
-                        "Received an invalid type in response to RPC `call` method".to_string(),
+                    return Err(Box::new(RpcError::owned(
+                        INVALID_PARAMS_CODE,
+                        "received an invalid type in response to RPC `call` method".to_string(),
+                        None::<()>,
                     )) as Box<dyn std::error::Error>);
                 }
             },
             _ => {
-                return Err(Box::new(RpcError::Custom(
-                    "Received an invalid type in response to RPC `call` method".to_string(),
+                return Err(Box::new(RpcError::owned(
+                    INVALID_PARAMS_CODE,
+                    "received an invalid type in response to RPC `call` method".to_string(),
+                    None::<()>,
                 )) as Box<dyn std::error::Error>);
             }
         }
@@ -191,14 +195,18 @@ macro_rules! create_handler {
                     return Ok(resp);
                 }
                 _ => {
-                    return Err(Box::new(RpcError::Custom(
-                        "Received an invalid type in response to RPC `send` method".to_string(),
+                    return Err(Box::new(RpcError::owned(
+                        INVALID_PARAMS_CODE,
+                        "received an invalid type in response to RPC `send` method".to_string(),
+                        None::<()>,
                     )) as Box<dyn std::error::Error>);
                 }
             },
             _ => {
-                return Err(Box::new(RpcError::Custom(
-                    "Received an invalid type in response to RPC `send` method".to_string(),
+                return Err(Box::new(RpcError::owned(
+                    INVALID_PARAMS_CODE,
+                    "received an invalid type in response to RPC `send` method".to_string(),
+                    None::<()>,
                 )) as Box<dyn std::error::Error>);
             }
         }
@@ -210,16 +218,20 @@ macro_rules! create_handler {
                 Ok(resp) => return Ok(resp),
 
                 _ => {
-                    return Err(Box::new(RpcError::Custom(
-                        "Received an invalid type in response to RPC `registerProgram` method"
+                    return Err(Box::new(RpcError::owned(
+                        INVALID_PARAMS_CODE,
+                        "received an invalid type in response to RPC `registerProgram` method"
                             .to_string(),
+                        None::<()>,
                     )) as Box<dyn std::error::Error>);
                 }
             },
             _ => {
-                return Err(Box::new(RpcError::Custom(
-                    "Received an invalid type in response to RPC `registerProgram` method"
+                return Err(Box::new(RpcError::owned(
+                    INVALID_PARAMS_CODE,
+                    "received an invalid type in response to RPC `registerProgram` method"
                         .to_string(),
+                    None::<()>,
                 )) as Box<dyn std::error::Error>);
             }
         }
@@ -232,15 +244,19 @@ macro_rules! create_handler {
                     return Ok(TransactionResponse::GetAccountResponse(account))
                 }
                 _ => {
-                    return Err(Box::new(RpcError::Custom(
+                    return Err(Box::new(RpcError::owned(
+                        INVALID_PARAMS_CODE,
                         "received an invalid type in response to RPC `getAccount` method"
                             .to_string(),
+                        None::<()>,
                     )) as Box<dyn std::error::Error>);
                 }
             },
             _ => {
-                return Err(Box::new(RpcError::Custom(
-                    "Received an invalid type in response to RPC `getAccount` method".to_string(),
+                return Err(Box::new(RpcError::owned(
+                    INVALID_PARAMS_CODE,
+                    "received an invalid type in response to RPC `getAccount` method".to_string(),
+                    None::<()>,
                 )) as Box<dyn std::error::Error>)
             }
         }

--- a/crates/actors/src/scheduler.rs
+++ b/crates/actors/src/scheduler.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::stream::FuturesUnordered;
-use jsonrpsee::core::Error as RpcError;
+use jsonrpsee::types::ErrorObjectOwned as RpcError;
 use lasr_messages::{
     AccountCacheMessage, ActorName, ActorType, DaClientMessage, EngineMessage, EoMessage,
     RpcMessage, RpcResponseError, SchedulerMessage, SupervisorType, TransactionResponse,

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,7 +24,7 @@ secp256k1 = { version = "0.28.0", features = [
 ] }
 ethereum-types = "0.14.1"
 tokio = { version = "1.34.0", features = ["full"] }
-jsonrpsee = { version = "0.16.2", features = [
+jsonrpsee = { version = "0.22.5", features = [
   "macros",
   "client-core",
   "server-core",

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -21,3 +21,6 @@ ethereum-types = "0.14.1"
 thiserror = "1.0.50"
 eo_listener = { git = "https://github.com/versatus/eo_listener" }
 eigenda_client = { git = "https://github.com/versatus/eigenda_client" }
+jsonrpsee = { version = "0.22.5", features = [
+  "full"
+] }

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -21,6 +21,4 @@ ethereum-types = "0.14.1"
 thiserror = "1.0.50"
 eo_listener = { git = "https://github.com/versatus/eo_listener" }
 eigenda_client = { git = "https://github.com/versatus/eigenda_client" }
-jsonrpsee = { version = "0.22.5", features = [
-  "full"
-] }
+jsonrpsee = { version = "0.22.5", features = ["full"] }

--- a/crates/messages/src/messages.rs
+++ b/crates/messages/src/messages.rs
@@ -5,7 +5,6 @@ use eigenda_client::proof::BlobVerificationProof;
 use eigenda_client::response::BlobResponse;
 use eo_listener::EventType;
 use ethereum_types::H256;
-use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
 use lasr_types::{Account, Certificate, Outputs, Transaction};
 use lasr_types::{Address, Token, U256};
 use ractor::concurrency::OneshotSender;

--- a/crates/messages/src/messages.rs
+++ b/crates/messages/src/messages.rs
@@ -5,6 +5,7 @@ use eigenda_client::proof::BlobVerificationProof;
 use eigenda_client::response::BlobResponse;
 use eo_listener::EventType;
 use ethereum_types::H256;
+use jsonrpsee::types::{ErrorCode, ErrorObjectOwned};
 use lasr_types::{Account, Certificate, Outputs, Transaction};
 use lasr_types::{Address, Token, U256};
 use ractor::concurrency::OneshotSender;

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.34.0", features = ["full"] }
 tokio-stream = "0.1.14"
 tokio-rayon = "2.1.0"
 num_cpus = "1.16.0"
-jsonrpsee = { version = "0.16.2", features = [
+jsonrpsee = { version = "0.22.5", features = [
   "macros",
   "client-core",
   "server-core",

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -418,6 +418,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let lasr_rpc = LasrRpcServerImpl::new(lasr_rpc_actor_ref);
     let port = std::env::var("PORT").unwrap_or_else(|_| "9292".to_string());
     let server = RpcServerBuilder::default()
+        .max_connections(1000)
         .build(format!("0.0.0.0:{}", port))
         .await
         .map_err(Box::new)?;

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -422,7 +422,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build(format!("0.0.0.0:{}", port))
         .await
         .map_err(Box::new)?;
-    let server_handle = server.start(lasr_rpc.into_rpc()).map_err(Box::new)?;
+    let server_handle = server.start(lasr_rpc.into_rpc());
     let eo_server_wrapper = EoServerWrapper::new(inner_eo_server);
 
     let (_stop_tx, stop_rx) = tokio::sync::mpsc::channel(1);

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -29,7 +29,7 @@ use web3::types::BlockNumber;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    simple_logger::init_with_level(log::Level::Warn)
+    simple_logger::init_with_level(log::Level::Error)
         .map_err(|e| EoServerError::Other(e.to_string()))?;
 
     log::info!("Current Working Directory: {:?}", std::env::current_dir());

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -4,12 +4,7 @@ version = "0.9.0"
 edition = "2021"
 
 [dependencies]
-jsonrpsee = { version = "0.16.2", features = [
-  "macros",
-  "client-core",
-  "server-core",
-  "server",
-  "http-client",
-  "ws-client",
+jsonrpsee = { version = "0.22.5", features = [
+  "full"
 ] }
 lasr_types = { path = "../types" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -4,7 +4,5 @@ version = "0.9.0"
 edition = "2021"
 
 [dependencies]
-jsonrpsee = { version = "0.22.5", features = [
-  "full"
-] }
+jsonrpsee = { version = "0.22.5", features = ["full"] }
 lasr_types = { path = "../types" }

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -1,18 +1,18 @@
-use jsonrpsee::{proc_macros::rpc, types::ErrorObjectOwned};
+use jsonrpsee::{proc_macros::rpc, types::ErrorObjectOwned as RpcError};
 use lasr_types::Transaction;
 
 #[rpc(client, server, namespace = "lasr")]
 #[async_trait::async_trait]
 pub trait LasrRpc {
     #[method(name = "call")]
-    async fn call(&self, transaction: Transaction) -> Result<String, ErrorObjectOwned>;
+    async fn call(&self, transaction: Transaction) -> Result<String, RpcError>;
 
     #[method(name = "send")]
-    async fn send(&self, transaction: Transaction) -> Result<String, ErrorObjectOwned>;
+    async fn send(&self, transaction: Transaction) -> Result<String, RpcError>;
 
     #[method(name = "registerProgram")]
-    async fn register_program(&self, transaction: Transaction) -> Result<String, ErrorObjectOwned>;
+    async fn register_program(&self, transaction: Transaction) -> Result<String, RpcError>;
 
     #[method(name = "getAccount")]
-    async fn get_account(&self, address: String) -> Result<String, ErrorObjectOwned>;
+    async fn get_account(&self, address: String) -> Result<String, RpcError>;
 }

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -1,19 +1,18 @@
-use jsonrpsee::core::Error;
-use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::{proc_macros::rpc, types::ErrorObjectOwned};
 use lasr_types::Transaction;
 
 #[rpc(client, server, namespace = "lasr")]
 #[async_trait::async_trait]
 pub trait LasrRpc {
     #[method(name = "call")]
-    async fn call(&self, transaction: Transaction) -> Result<String, Error>;
+    async fn call(&self, transaction: Transaction) -> Result<String, ErrorObjectOwned>;
 
     #[method(name = "send")]
-    async fn send(&self, transaction: Transaction) -> Result<String, Error>;
+    async fn send(&self, transaction: Transaction) -> Result<String, ErrorObjectOwned>;
 
     #[method(name = "registerProgram")]
-    async fn register_program(&self, transaction: Transaction) -> Result<String, Error>;
+    async fn register_program(&self, transaction: Transaction) -> Result<String, ErrorObjectOwned>;
 
     #[method(name = "getAccount")]
-    async fn get_account(&self, address: String) -> Result<String, Error>;
+    async fn get_account(&self, address: String) -> Result<String, ErrorObjectOwned>;
 }


### PR DESCRIPTION
Closes #189 
Bumps jsonrpsee dep to `0.22.5` and handles API changes.
Increases RPC server connection to `1000`, default was `100`.

This PR is ready, but
**BEFORE MERGE:**
- [x] Merged: https://github.com/versatus/versatus/pull/798


This has been tested in regard to compilation, by setting the `internal_rpc` dependency to the branch mentioned above.