### PR TITLE
Reacquire `EoServerActor` after `ActorStatus::Stopped` in `EoServerActor::run()`

### DIFF
--- a/crates/actors/src/eo_server.rs
+++ b/crates/actors/src/eo_server.rs
@@ -48,43 +48,48 @@ impl EoServerWrapper {
     }
 
     pub async fn run(mut self) -> Result<(), EoServerError> {
-        let eo_actor: ActorRef<EoMessage> =
-            ractor::registry::where_is(ActorType::EoServer.to_string())
-                .ok_or(EoServerError::Custom(
-                    "unable to acquire eo_actor".to_string(),
-                ))?
-                .into();
-
-        log::info!("attempting to load processed blocks");
-        if let Err(e) = self.server.load_processed_blocks().await {
-            log::error!("unable to load processed blocks from file: {}", e);
-        }
-
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(15));
+        // loop to reacquire the eo_server actor if it stops
         loop {
-            let logs = self.server.next().await;
-            match &logs.log_result {
-                Ok(log) => {
-                    if !log.is_empty() {
-                        log::info!("non-empty log found: {:?}", log);
-                        eo_actor
-                            .cast(EoMessage::Log {
-                                log_type: logs.event_type,
-                                log: log.to_vec(),
-                            })
-                            .map_err(|e| EoServerError::Custom(e.to_string()))?;
+            let eo_actor: ActorRef<EoMessage> =
+                ractor::registry::where_is(ActorType::EoServer.to_string())
+                    .ok_or(EoServerError::Custom(
+                        "unable to acquire eo_actor".to_string(),
+                    ))?
+                    .into();
 
-                        self.server.save_blocks_processed();
+            log::info!("attempting to load processed blocks");
+            if let Err(e) = self.server.load_processed_blocks().await {
+                log::error!("unable to load processed blocks from file: {}", e);
+            }
+
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(15));
+            loop {
+                let logs = self.server.next().await;
+                match &logs.log_result {
+                    Ok(log) => {
+                        if !log.is_empty() {
+                            log::info!("non-empty log found: {:?}", log);
+                            eo_actor
+                                .cast(EoMessage::Log {
+                                    log_type: logs.event_type,
+                                    log: log.to_vec(),
+                                })
+                                .map_err(|e| EoServerError::Custom(e.to_string()))?;
+
+                            self.server.save_blocks_processed();
+                        }
                     }
+                    Err(e) => log::error!("EoServer Error: server log returned an error: {e:?}"),
                 }
-                Err(e) => log::error!("EoServer Error: server log returned an error: {e:?}"),
-            }
 
-            if let ActorStatus::Stopped = eo_actor.get_status() {
-                log::error!("EO Actor stopped");
-                break;
+                if let ActorStatus::Stopped = eo_actor.get_status() {
+                    log::error!(
+                        "EoServerActor stopped! Waiting 15s, then attempting to reacquire EoServerActor..."
+                    );
+                    break;
+                }
+                interval.tick().await;
             }
-            interval.tick().await;
         }
 
         Ok(())


### PR DESCRIPTION
Catches a potential edge case where the `EoServerActor::run()` method will exit and stop checking the server for logs.