### PR TITLE
Add testing framework for events that update `Account`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,13 @@ jobs:
           crate: taplo-cli
       - name: Run taplo linter
         run: taplo format --check --verbose
+
+  cargo-test-workspace:
+    name: test workspace crates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install toolchain
+        uses: dsherret/rust-toolchain-file@v1
+      - name: Test Workspace
+        run: cargo test --workspace --features mock_storage

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "internal_rpc"
 version = "0.9.0"
-source = "git+https://github.com/versatus/versatus.git?branch=andrewvious/797#23c6eef5e806804bbd87ea533d0b03a7862953d0"
+source = "git+https://github.com/versatus/versatus.git#217a0e73fa9284286e1482d50c2af260ada4f51c"
 dependencies = [
  "anyhow",
  "jsonrpsee 0.22.5",
@@ -2406,7 +2406,7 @@ dependencies = [
  "service_config",
  "tokio",
  "uuid",
- "web3_pkg 0.9.0 (git+https://github.com/versatus/versatus.git?branch=andrewvious/797)",
+ "web3_pkg",
 ]
 
 [[package]]
@@ -2972,7 +2972,7 @@ dependencies = [
  "tokio",
  "uint",
  "walkdir",
- "web3_pkg 0.9.0 (git+https://github.com/versatus/versatus.git)",
+ "web3_pkg",
 ]
 
 [[package]]
@@ -2997,7 +2997,7 @@ dependencies = [
  "tokio",
  "toml 0.8.12",
  "walkdir",
- "web3_pkg 0.9.0 (git+https://github.com/versatus/versatus.git)",
+ "web3_pkg",
 ]
 
 [[package]]
@@ -3058,7 +3058,7 @@ dependencies = [
  "tokio-rayon",
  "tokio-stream",
  "web3",
- "web3_pkg 0.9.0 (git+https://github.com/versatus/versatus.git)",
+ "web3_pkg",
 ]
 
 [[package]]
@@ -3676,7 +3676,7 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 [[package]]
 name = "platform"
 version = "0.9.0"
-source = "git+https://github.com/versatus/versatus.git?branch=andrewvious/797#23c6eef5e806804bbd87ea533d0b03a7862953d0"
+source = "git+https://github.com/versatus/versatus.git#217a0e73fa9284286e1482d50c2af260ada4f51c"
 dependencies = [
  "anyhow",
  "bitmask-enum",
@@ -4784,7 +4784,7 @@ dependencies = [
 [[package]]
 name = "service_config"
 version = "0.9.0"
-source = "git+https://github.com/versatus/versatus.git?branch=andrewvious/797#23c6eef5e806804bbd87ea533d0b03a7862953d0"
+source = "git+https://github.com/versatus/versatus.git#217a0e73fa9284286e1482d50c2af260ada4f51c"
 dependencies = [
  "anyhow",
  "serde",
@@ -5856,25 +5856,6 @@ dependencies = [
  "hex",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "web3_pkg"
-version = "0.9.0"
-source = "git+https://github.com/versatus/versatus.git?branch=andrewvious/797#23c6eef5e806804bbd87ea533d0b03a7862953d0"
-dependencies = [
- "anyhow",
- "clap 3.2.25",
- "derive_builder 0.12.0",
- "futures",
- "http 0.2.12",
- "ipfs-api",
- "ipfs-api-backend-hyper",
- "serde",
- "serde_derive",
- "serde_json",
- "tokio",
- "trust-dns-resolver",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,6 +3023,8 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror",
+ "tikv-client",
+ "tokio",
  "typetag",
  "uint",
  "web3-signature",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,6 +2880,7 @@ dependencies = [
  "secp256k1 0.28.2",
  "serde",
  "serde_json",
+ "serial_test",
  "sha3",
  "thiserror",
  "tikv-client",
@@ -4526,6 +4527,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ad2bbb0ae5100a07b7a6f2ed7ab5fd0045551a4c507989b7a620046ea3efdc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4573,6 +4583,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sdd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "sec1"
@@ -4724,6 +4740,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["local"]
+default = ["local", "mock_storage"]
 local = []
 remote = []
+mock_storage = []
 
 [dependencies]
 ethereum-types = "0.14.1"

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -69,3 +69,4 @@ dotenv = "0.15.0"
 
 [dev-dependencies]
 anyhow = "1"
+serial_test = "3.1.1"

--- a/crates/actors/src/account_cache.rs
+++ b/crates/actors/src/account_cache.rs
@@ -21,6 +21,8 @@ use tokio::sync::mpsc::Sender;
 #[derive(Debug, Clone, Default)]
 pub struct AccountCacheActor;
 
+pub type StorageRef = <AccountCacheActor as Actor>::Arguments;
+
 impl ActorName for AccountCacheActor {
     fn name(&self) -> ractor::ActorName {
         ActorType::AccountCache.to_string()

--- a/crates/actors/src/account_cache.rs
+++ b/crates/actors/src/account_cache.rs
@@ -5,7 +5,9 @@ use lasr_messages::{
     AccountCacheMessage, ActorName, ActorType, RpcMessage, RpcResponseError, SupervisorType,
     TransactionResponse,
 };
-use lasr_types::{Account, AccountType, Address, MockPersistenceStore, PersistenceStore};
+#[cfg(feature = "mock_storage")]
+use lasr_types::MockPersistenceStore;
+use lasr_types::{Account, AccountType, Address, PersistenceStore};
 use ractor::{
     concurrency::OneshotReceiver, Actor, ActorCell, ActorProcessingErr, ActorRef, SupervisionEvent,
 };
@@ -251,7 +253,7 @@ impl Actor for AccountCacheActor {
                     // Pull `Account` data from persistence store
                     PersistenceStore::get(
                         &state.storage,
-                        <Self::Arguments as PersistenceStore>::Key::from(acc_key.to_owned())
+                        acc_key.to_owned().into()
                     )
                     .await
                     .typecast()

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -1720,7 +1720,7 @@ impl Batcher {
                         let acc_val = AccountValue { account: data };
                         // Serialize `Account` data to be stored.
                         if let Some(val) = bincode::serialize(&acc_val).ok() {
-                            if PersistenceStore::put(&storage_ref, addr.clone(), val)
+                            if PersistenceStore::put(&storage_ref, addr.clone().into(), val)
                                 .await
                                 .is_ok()
                             {

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -444,7 +444,7 @@ impl Batcher {
         Ok(())
     }
 
-    pub(super) async fn add_transaction_to_account(
+    pub async fn add_transaction_to_account(
         batcher: Arc<Mutex<Batcher>>,
         transaction: Transaction,
     ) -> Result<(), BatcherError> {

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -43,7 +43,7 @@ use web3::types::BlockNumber;
 use crate::{
     account_cache, get_account, get_actor_ref, handle_actor_response, process_group_changed,
     AccountCacheActor, AccountCacheError, ActorExt, Coerce, DaClientError, EoClientError,
-    PendingTransactionError, SchedulerError, StaticFuture, UnorderedFuturePool,
+    PendingTransactionError, SchedulerError, StaticFuture, StorageRef, UnorderedFuturePool,
 };
 use lasr_messages::{
     AccountCacheMessage, ActorName, ActorType, BatcherMessage, DaClientMessage, EoMessage,
@@ -1703,7 +1703,7 @@ impl Batcher {
 
     async fn handle_next_batch_request(
         batcher: Arc<Mutex<Batcher>>,
-        storage_ref: <AccountCacheActor as Actor>::Arguments,
+        storage_ref: StorageRef,
     ) -> Result<(), BatcherError> {
         if let Some(blob_response) = {
             let mut guard = batcher.lock().await;
@@ -2056,7 +2056,7 @@ impl Actor for BatcherSupervisor {
 
 pub async fn batch_requestor(
     mut stopper: tokio::sync::mpsc::Receiver<u8>,
-    storage_ref: <AccountCacheActor as Actor>::Arguments,
+    storage_ref: StorageRef,
 ) {
     if let Some(batcher) = ractor::registry::where_is(ActorType::Batcher.to_string()) {
         let batcher: ActorRef<BatcherMessage> = batcher.into();

--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -1333,7 +1333,7 @@ impl Batcher {
         }
     }
 
-    async fn apply_program_registration(
+    pub async fn apply_program_registration(
         batcher: Arc<Mutex<Batcher>>,
         transaction: Transaction,
     ) -> Result<(), BatcherError> {
@@ -1498,7 +1498,7 @@ impl Batcher {
         }
     }
 
-    async fn apply_instructions_to_accounts(
+    pub async fn apply_instructions_to_accounts(
         batcher: Arc<Mutex<Batcher>>,
         transaction: Transaction,
         outputs: Outputs,

--- a/crates/actors/src/eo_server.rs
+++ b/crates/actors/src/eo_server.rs
@@ -119,13 +119,10 @@ pub async fn update_blocks_processed_in_persistence(
     file.read_to_end(&mut buf)
         .map_err(|e| EoServerError::Custom(e.to_string()))?;
 
-    PersistenceStore::get(
-        &storage,
-        <StorageRef as PersistenceStore>::Key::from(STORAGE_PROCESSED_BLOCKS_KEY.to_string()),
-    )
-    .await
-    .typecast()
-    .log_err(|e| e);
+    PersistenceStore::get(&storage, STORAGE_PROCESSED_BLOCKS_KEY.to_string().into())
+        .await
+        .typecast()
+        .log_err(|e| e);
 
     Ok(())
 }

--- a/crates/actors/src/manager.rs
+++ b/crates/actors/src/manager.rs
@@ -15,7 +15,7 @@ use crate::{
     DaClientSupervisorError, EngineActor, EngineSupervisorError, EoClient, EoClientActor,
     EoClientSupervisorError, EoServerActor, EoServerSupervisorError, ExecutionEngine,
     ExecutorActor, ExecutorSupervisorError, LasrRpcServerActor, LasrRpcServerSupervisorError,
-    PendingTransactionActor, PendingTransactionSupervisorError, TaskScheduler,
+    PendingTransactionActor, PendingTransactionSupervisorError, StorageRef, TaskScheduler,
     TaskSchedulerSupervisorError, ValidatorActor, ValidatorCore, ValidatorSupervisorError,
 };
 
@@ -86,7 +86,7 @@ impl ActorManager {
         actor_manager: Arc<Mutex<ActorManager>>,
         actor_name: ractor::ActorName,
         handler: AccountCacheActor,
-        startup_args: <AccountCacheActor as Actor>::Arguments,
+        startup_args: StorageRef,
     ) -> Result<(), ActorManagerError> {
         if let Some(supervisor) = get_actor_ref::<AccountCacheMessage, AccountCacheSupervisorError>(
             SupervisorType::AccountCache,
@@ -437,7 +437,7 @@ impl ActorManagerBuilder {
     pub async fn account_cache(
         self,
         account_cache_actor: AccountCacheActor,
-        startup_args: <AccountCacheActor as Actor>::Arguments,
+        startup_args: StorageRef,
         account_cache_supervisor: ActorRef<AccountCacheMessage>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut new = self;

--- a/crates/actors/src/manager.rs
+++ b/crates/actors/src/manager.rs
@@ -7,7 +7,6 @@ use lasr_messages::{
 use ractor::{concurrency::JoinHandle, Actor, ActorRef};
 use std::sync::Arc;
 use thiserror::Error;
-use tikv_client::RawClient as TikvClient;
 use tokio::sync::Mutex;
 
 use crate::{
@@ -87,7 +86,7 @@ impl ActorManager {
         actor_manager: Arc<Mutex<ActorManager>>,
         actor_name: ractor::ActorName,
         handler: AccountCacheActor,
-        startup_args: TikvClient,
+        startup_args: <AccountCacheActor as Actor>::Arguments,
     ) -> Result<(), ActorManagerError> {
         if let Some(supervisor) = get_actor_ref::<AccountCacheMessage, AccountCacheSupervisorError>(
             SupervisorType::AccountCache,
@@ -438,7 +437,7 @@ impl ActorManagerBuilder {
     pub async fn account_cache(
         self,
         account_cache_actor: AccountCacheActor,
-        startup_args: TikvClient,
+        startup_args: <AccountCacheActor as Actor>::Arguments,
         account_cache_supervisor: ActorRef<AccountCacheMessage>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let mut new = self;

--- a/crates/actors/tests/account.rs
+++ b/crates/actors/tests/account.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-//! Test events that make changes to `Account`s.
+//! Test coverage for events that make changes to `Account`.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -7,7 +7,8 @@ use std::{
 };
 
 use lasr_actors::{
-    get_actor_ref, AccountCacheActor, AccountCacheError, Batcher, BatcherActor, TaskScheduler,
+    get_actor_ref, AccountCacheActor, AccountCacheError, Batcher, BatcherActor,
+    PendingTransactionActor, TaskScheduler,
 };
 use lasr_messages::{AccountCacheMessage, ActorName, ActorType};
 use lasr_types::{
@@ -29,7 +30,7 @@ pub fn empty_account() -> Account {
 pub fn sender_test_account_pair() -> (Account, Account) {
     const SENDER_ADDRESS: [u8; 20] = [1; 20];
     const SENDER_PROGRAM_NAMESPACE: &str = "SENDER_PROGRAM_NAMESPACE";
-    const SENDER_PROGRAM_ADDRESS: [u8; 20] = [0; 20];
+    const SENDER_PROGRAM_ADDRESS: [u8; 20] = [2; 20];
     const STARTING_TOKEN_BALANCE: u32 = 1000;
     const TOKEN_ID_0: u32 = 100;
 
@@ -86,13 +87,45 @@ async fn bridge_in_event() {
     // Channel is not used, but is necessary to construct a `Batcher` and cannot be zero.
     const CHANNEL_BUFFER: usize = 1;
     let (receivers_thread_tx, _receivers_thread_rx) = tokio::sync::mpsc::channel(CHANNEL_BUFFER);
+    let batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
+    let batcher_actor = BatcherActor::new();
+    let (_batcher_ref, _batcher_handle) =
+        Actor::spawn(Some(batcher_actor.name()), batcher_actor, batcher.clone())
+            .await
+            .expect("failed to spawn batcher actor");
 
     let mock_storage = <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::new()
         .await
         .expect("failed to create mock persistence storage");
+    let account_cache_actor = AccountCacheActor::new();
+    let (_account_cache_ref, _account_cache_handle) = Actor::spawn(
+        Some(account_cache_actor.name()),
+        account_cache_actor,
+        mock_storage.clone(),
+    )
+    .await
+    .expect("failed to spawn account cache actor");
 
-    // Insert accounts into storage & account cache
+    let scheduler_actor = TaskScheduler::new();
+    let (_scheduler_ref, _scheduler_handle) =
+        Actor::spawn(Some(scheduler_actor.name()), scheduler_actor, ())
+            .await
+            .expect("failed to spawn scheduler actor");
+
+    let pending_transaction_actor = PendingTransactionActor::new();
+    let (_pending_transaction_ref, _pending_transaction_handle) = Actor::spawn(
+        Some(pending_transaction_actor.name()),
+        pending_transaction_actor,
+        (),
+    )
+    .await
+    .expect("failed to spawn pending transaction actor");
+
+    // Insert from accounts into storage & account cache
     let (from_account, from_program_account) = sender_test_account_pair();
+    let AccountType::Program(from_program_address) = from_program_account.account_type() else {
+        panic!("from_program_account is not a program account.")
+    };
     assert!(
         <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
             &mock_storage,
@@ -111,19 +144,11 @@ async fn bridge_in_event() {
             .await
             .is_ok()
     );
-    let account_cache_actor = AccountCacheActor::new();
-    let (_account_cache_ref, _account_cache_handle) = Actor::spawn(
-        Some(account_cache_actor.name()),
-        account_cache_actor,
-        mock_storage,
-    )
-    .await
-    .expect("failed to spawn account cache actor");
     assert!(
         get_actor_ref::<AccountCacheMessage, AccountCacheError>(ActorType::AccountCache)
             .and_then(|account_cache| account_cache
                 .send_message(AccountCacheMessage::Write {
-                    account: from_account,
+                    account: from_account.clone(),
                     who: ActorType::AccountCache,
                     location: "bridge_in_event test".into(),
                 })
@@ -140,25 +165,28 @@ async fn bridge_in_event() {
             .is_some()
     );
 
-    let scheduler_actor = TaskScheduler::new();
-    let (_scheduler_ref, _scheduler_handle) =
-        Actor::spawn(Some(scheduler_actor.name()), scheduler_actor, ())
-            .await
-            .expect("failed to spawn scheduler actor");
-
-    let batcher_actor = BatcherActor::new();
-    let batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
-    let (_batcher_ref, _batcher_handle) =
-        Actor::spawn(Some(batcher_actor.name()), batcher_actor, batcher.clone())
-            .await
-            .expect("failed to spawn batcher actor");
-
     let to_account = empty_account();
 
     const BRIDGE_IN_AMOUNT: u64 = 1;
-    let bridge_transaction = Transaction::bridge_in(BRIDGE_IN_AMOUNT, to_account.owner_address());
-    let res = Batcher::add_transaction_to_account(batcher, bridge_transaction).await;
-    dbg!(&res);
+    let bridge_in_transaction = Transaction::bridge_in(
+        BRIDGE_IN_AMOUNT,
+        from_account.owner_address(),
+        from_program_address,
+        to_account.owner_address(),
+    );
+    let res = Batcher::add_transaction_to_account(batcher, bridge_in_transaction).await;
 
     assert!(res.is_ok());
+    assert_eq!(from_account.balance(&from_program_address), U256::from(999));
+    assert_eq!(
+        to_account.balance(&Default::default()),
+        U256::from(BRIDGE_IN_AMOUNT)
+    );
+    // drop all actors, not strictly necessary.
+    let (_, _, _, _) = (
+        _batcher_handle,
+        _account_cache_handle,
+        _scheduler_handle,
+        _pending_transaction_handle,
+    );
 }

--- a/crates/actors/tests/account.rs
+++ b/crates/actors/tests/account.rs
@@ -464,8 +464,9 @@ async fn call_create_event() {
             .is_some());
 
             const TOKEN_AMOUNT: u64 = 1;
-            let create_transaction = Transaction::test_create(
+            let create_transaction = Transaction::test_call(
                 from_account.nonce(),
+                from_account_address,
                 from_account_address,
                 from_program_address,
             );
@@ -585,8 +586,9 @@ async fn call_burn_event() {
             .is_some());
 
             const TOKEN_AMOUNT: u64 = 1;
-            let burn_transaction = Transaction::test_create(
+            let burn_transaction = Transaction::test_call(
                 from_account.nonce(),
+                from_account_address,
                 from_account_address,
                 from_program_address,
             );

--- a/crates/actors/tests/account.rs
+++ b/crates/actors/tests/account.rs
@@ -6,19 +6,29 @@ use std::{
     sync::Arc,
 };
 
+use anyhow::Ok;
+use eigenda_client::proof::BlobVerificationProof;
+use futures::TryFutureExt;
 use lasr_actors::{
     get_account, get_actor_ref, AccountCacheActor, AccountCacheError, Batcher, BatcherActor,
     PendingTransactionActor, TaskScheduler, ETH_ADDR,
 };
-use lasr_messages::{AccountCacheMessage, ActorName, ActorType};
+use lasr_messages::{
+    AccountCacheMessage, ActorName, ActorType, BatcherMessage, PendingTransactionMessage,
+    SchedulerMessage,
+};
 use lasr_types::{
-    Account, AccountBuilder, AccountType, Address, AddressOrNamespace, ArbitraryData, Metadata,
-    MockPersistenceStore, Namespace, PersistenceStore, Status, TokenBuilder, Transaction, U256,
+    Account, AccountBuilder, AccountType, Address, AddressOrNamespace, ArbitraryData,
+    CreateInstructionBuilder, Inputs, Metadata, MockPersistenceStore, Namespace, OutputsBuilder,
+    PersistenceStore, Status, TokenBuilder, TokenDistributionBuilder, Transaction, U256,
 };
 
-use ractor::Actor;
+use ractor::{
+    concurrency::{JoinHandle, OneshotReceiver},
+    Actor, ActorRef,
+};
 use serial_test::serial;
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 
 /// This is an account with nothing in it, with `Address([1; 20])`.
 pub fn receiver_test_account() -> Account {
@@ -80,60 +90,120 @@ pub fn sender_test_account_pair() -> (Account, Account) {
     )
 }
 
+/// Everything needed to run minimal tests for a node. This excludes most things
+/// that use JRPC, IPFS, and compute related components.
+pub struct MinimalNode {
+    /// Receiver end of the channel must outlive the function if it's to be used
+    /// in future tests that require it.
+    _batcher_rx: mpsc::Receiver<OneshotReceiver<(String, BlobVerificationProof)>>,
+    pub batcher: Arc<Mutex<Batcher>>,
+    pub batcher_actor: (ActorRef<BatcherMessage>, JoinHandle<()>),
+
+    /// An in-memory flavor of `PersistenceStore`, i.e. `HashMap`.
+    pub mock_storage: MockPersistenceStore<String, Vec<u8>>,
+    pub account_cache_actor: (ActorRef<AccountCacheMessage>, JoinHandle<()>),
+
+    pub scheduler_actor: (ActorRef<SchedulerMessage>, JoinHandle<()>),
+
+    pub pending_transaction_actor: (ActorRef<PendingTransactionMessage>, JoinHandle<()>),
+}
+impl MinimalNode {
+    /// Create a new `MinimalNode` !!
+    ///
+    /// Example:
+    /// ```rust, ignore
+    /// #[cfg(test)]
+    /// mod my_node_tests {
+    ///     use super::MinimalNode;
+    ///     use futures::TryFutureExt;
+    ///     
+    ///     #[test]
+    ///     fn my_node_test() {
+    ///         MinimalNode::new().and_then(|node| async move { ... }).await.unwrap();
+    ///     }
+    /// }
+    /// ```
+    async fn new() -> anyhow::Result<Self> {
+        // Channel is not used, but is necessary to construct a `Batcher` and cannot be zero.
+        const CHANNEL_BUFFER: usize = 1;
+        let (receivers_thread_tx, _batcher_rx) = mpsc::channel(CHANNEL_BUFFER);
+        let batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
+        let batcher_actor = BatcherActor::new();
+        let batcher_actor =
+            Actor::spawn(Some(batcher_actor.name()), batcher_actor, batcher.clone()).await?;
+
+        let mock_storage =
+            <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::new().await?;
+        let account_cache_actor = AccountCacheActor::new();
+        let account_cache_actor = Actor::spawn(
+            Some(account_cache_actor.name()),
+            account_cache_actor,
+            mock_storage.clone(),
+        )
+        .await?;
+
+        let scheduler_actor = TaskScheduler::new();
+        let scheduler_actor =
+            Actor::spawn(Some(scheduler_actor.name()), scheduler_actor, ()).await?;
+
+        let pending_transaction_actor = PendingTransactionActor::new();
+        let pending_transaction_actor = Actor::spawn(
+            Some(pending_transaction_actor.name()),
+            pending_transaction_actor,
+            (),
+        )
+        .await?;
+
+        Ok(MinimalNode {
+            _batcher_rx,
+            batcher,
+            batcher_actor,
+            mock_storage,
+            account_cache_actor,
+            scheduler_actor,
+            pending_transaction_actor,
+        })
+    }
+
+    /// Shutdown the node processes and wait.
+    async fn shutdown_and_wait(self) -> anyhow::Result<()> {
+        self.batcher_actor.0.stop_and_wait(None, None).await.ok();
+        self.account_cache_actor
+            .0
+            .stop_and_wait(None, None)
+            .await
+            .ok();
+        self.scheduler_actor.0.stop_and_wait(None, None).await.ok();
+        self.pending_transaction_actor
+            .0
+            .stop_and_wait(None, None)
+            .await
+            .ok();
+        std::thread::sleep(std::time::Duration::from_secs(5));
+        Ok(())
+    }
+}
+
 #[serial]
 #[tokio::test]
 async fn bridge_in_event() {
-    // Channel is not used, but is necessary to construct a `Batcher` and cannot be zero.
-    const CHANNEL_BUFFER: usize = 1;
-    let (receivers_thread_tx, _receivers_thread_rx) = tokio::sync::mpsc::channel(CHANNEL_BUFFER);
-    let batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
-    let batcher_actor = BatcherActor::new();
-    let (batcher_ref, _batcher_handle) =
-        Actor::spawn(Some(batcher_actor.name()), batcher_actor, batcher.clone())
-            .await
-            .expect("failed to spawn batcher actor");
-
-    let mock_storage = <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::new()
-        .await
-        .expect("failed to create mock persistence storage");
-    let account_cache_actor = AccountCacheActor::new();
-    let (account_cache_ref, _account_cache_handle) = Actor::spawn(
-        Some(account_cache_actor.name()),
-        account_cache_actor,
-        mock_storage.clone(),
-    )
-    .await
-    .expect("failed to spawn account cache actor");
-
-    let scheduler_actor = TaskScheduler::new();
-    let (scheduler_ref, _scheduler_handle) =
-        Actor::spawn(Some(scheduler_actor.name()), scheduler_actor, ())
-            .await
-            .expect("failed to spawn scheduler actor");
-
-    let pending_transaction_actor = PendingTransactionActor::new();
-    let (pending_transaction_ref, _pending_transaction_handle) = Actor::spawn(
-        Some(pending_transaction_actor.name()),
-        pending_transaction_actor,
-        (),
-    )
-    .await
-    .expect("failed to spawn pending transaction actor");
-
-    // Insert account into storage & account cache.
-    let to_account = receiver_test_account();
-    let to_account_address = to_account.owner_address();
-    assert!(
-        <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
-            &mock_storage,
-            to_account.owner_address().to_full_string(),
-            bincode::serialize(&to_account).expect("failed serialization of to address")
-        )
-        .await
-        .is_ok()
-    );
-    assert!(
-        get_actor_ref::<AccountCacheMessage, AccountCacheError>(ActorType::AccountCache)
+    MinimalNode::new()
+        .and_then(|node| async move {
+            // Insert account into storage & account cache.
+            let to_account = receiver_test_account();
+            let to_account_address = to_account.owner_address();
+            assert!(
+                <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+                    &node.mock_storage,
+                    to_account.owner_address().to_full_string(),
+                    bincode::serialize(&to_account).expect("failed serialization of to account")
+                )
+                .await
+                .is_ok()
+            );
+            assert!(get_actor_ref::<AccountCacheMessage, AccountCacheError>(
+                ActorType::AccountCache
+            )
             .and_then(|account_cache| account_cache
                 .send_message(AccountCacheMessage::Write {
                     account: to_account.clone(),
@@ -141,111 +211,85 @@ async fn bridge_in_event() {
                     location: "bridge_in_event test".into()
                 })
                 .ok())
-            .is_some()
-    );
+            .is_some());
 
-    const BRIDGE_IN_AMOUNT: u64 = 1;
-    let program_id = ETH_ADDR;
-    let bridge_in_transaction =
-        Transaction::test_bridge_in(BRIDGE_IN_AMOUNT, program_id, to_account_address);
-    let res = Batcher::add_transaction_to_account(batcher, bridge_in_transaction).await;
+            const BRIDGE_IN_AMOUNT: u64 = 1;
+            let program_id = ETH_ADDR;
+            let bridge_in_transaction = Transaction::test_bridge_in(
+                BRIDGE_IN_AMOUNT,
+                to_account.nonce(),
+                program_id,
+                to_account_address,
+            );
+            let res =
+                Batcher::add_transaction_to_account(node.batcher.clone(), bridge_in_transaction)
+                    .await;
 
-    let to_account_with_updates = get_account(to_account_address, ActorType::AccountCache)
+            let to_account_with_updates = get_account(to_account_address, ActorType::AccountCache)
+                .await
+                .expect("could not find to account");
+
+            assert!(res.is_ok());
+            assert_eq!(
+                to_account_with_updates.balance(&program_id),
+                U256::from(BRIDGE_IN_AMOUNT)
+            );
+
+            MinimalNode::shutdown_and_wait(node).await
+        })
         .await
-        .expect("could not find to account");
-
-    assert!(res.is_ok());
-    assert_eq!(
-        to_account_with_updates.balance(&program_id),
-        U256::from(BRIDGE_IN_AMOUNT)
-    );
-    batcher_ref.stop_and_wait(None, None).await.ok();
-    account_cache_ref.stop_and_wait(None, None).await.ok();
-    scheduler_ref.stop_and_wait(None, None).await.ok();
-    pending_transaction_ref.stop_and_wait(None, None).await.ok();
-    std::thread::sleep(std::time::Duration::from_secs(5));
+        .unwrap();
 }
 
 #[serial]
 #[tokio::test]
 async fn send_event() {
-    // Channel is not used, but is necessary to construct a `Batcher` and cannot be zero.
-    const CHANNEL_BUFFER: usize = 1;
-    let (receivers_thread_tx, _receivers_thread_rx) = tokio::sync::mpsc::channel(CHANNEL_BUFFER);
-    let batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
-    let batcher_actor = BatcherActor::new();
-    let (batcher_ref, _batcher_handle) =
-        Actor::spawn(Some(batcher_actor.name()), batcher_actor, batcher.clone())
-            .await
-            .expect("failed to spawn batcher actor");
-
-    let mock_storage = <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::new()
-        .await
-        .expect("failed to create mock persistence storage");
-    let account_cache_actor = AccountCacheActor::new();
-    let (account_cache_ref, _account_cache_handle) = Actor::spawn(
-        Some(account_cache_actor.name()),
-        account_cache_actor,
-        mock_storage.clone(),
-    )
-    .await
-    .expect("failed to spawn account cache actor");
-
-    let scheduler_actor = TaskScheduler::new();
-    let (scheduler_ref, _scheduler_handle) =
-        Actor::spawn(Some(scheduler_actor.name()), scheduler_actor, ())
-            .await
-            .expect("failed to spawn scheduler actor");
-
-    let pending_transaction_actor = PendingTransactionActor::new();
-    let (pending_transaction_ref, _pending_transaction_handle) = Actor::spawn(
-        Some(pending_transaction_actor.name()),
-        pending_transaction_actor,
-        (),
-    )
-    .await
-    .expect("failed to spawn pending transaction actor");
-
-    // Insert accounts into storage & account cache.
-    // This simulates an already registered program.
-    let (from_account, from_program_account) = sender_test_account_pair();
-    let from_account_address = from_account.owner_address();
-    let AccountType::Program(from_program_address) = from_program_account.account_type() else {
-        panic!("from_program_account is not a program account.")
-    };
-    let to_account = receiver_test_account();
-    let to_account_address = to_account.owner_address();
-    assert!(
-        <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
-            &mock_storage,
-            from_account.owner_address().to_full_string(),
-            bincode::serialize(&from_account).expect("failed serialization of from address")
-        )
-        .await
-        .is_ok()
-            && <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
-                &mock_storage,
-                from_program_account.owner_address().to_full_string(),
-                bincode::serialize(&from_program_account)
-                    .expect("failed serialization of from program address")
+    MinimalNode::new()
+        .and_then(|node| async move {
+            // Insert accounts into storage & account cache.
+            // This simulates an already registered program.
+            let (from_account, from_program_account) = sender_test_account_pair();
+            let from_account_address = from_account.owner_address();
+            let AccountType::Program(from_program_address) = from_program_account.account_type()
+            else {
+                panic!("from_program_account is not a program account.")
+            };
+            let to_account = receiver_test_account();
+            let to_account_address = to_account.owner_address();
+            assert!(
+                <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+                    &node.mock_storage,
+                    from_account.owner_address().to_full_string(),
+                    bincode::serialize(&from_account)
+                        .expect("failed serialization of from account")
+                )
+                .await
+                .is_ok()
+                    && <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+                        &node.mock_storage,
+                        from_program_address.to_full_string(),
+                        bincode::serialize(&from_program_account)
+                            .expect("failed serialization of from program account")
+                    )
+                    .await
+                    .is_ok()
+                    && <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+                        &node.mock_storage,
+                        to_account.owner_address().to_full_string(),
+                        bincode::serialize(&to_account)
+                            .expect("failed serialization of to account")
+                    )
+                    .await
+                    .is_ok()
+            );
+            assert!(get_actor_ref::<AccountCacheMessage, AccountCacheError>(
+                ActorType::AccountCache
             )
-            .await
-            .is_ok()
-            && <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
-                &mock_storage,
-                to_account.owner_address().to_full_string(),
-                bincode::serialize(&to_account).expect("failed serialization of to address")
-            )
-            .await
-            .is_ok()
-    );
-    assert!(
-        get_actor_ref::<AccountCacheMessage, AccountCacheError>(ActorType::AccountCache)
             .and_then(|account_cache| account_cache
                 .send_message(AccountCacheMessage::Write {
                     account: from_account.clone(),
                     who: ActorType::AccountCache,
-                    location: "bridge_in_event test".into(),
+                    location: "send_event test".into(),
                 })
                 .ok()
                 .zip(
@@ -253,7 +297,7 @@ async fn send_event() {
                         .send_message(AccountCacheMessage::Write {
                             account: from_program_account,
                             who: ActorType::AccountCache,
-                            location: "bridge_in_event test".into()
+                            location: "send_event test".into()
                         })
                         .ok()
                 )
@@ -262,41 +306,249 @@ async fn send_event() {
                         .send_message(AccountCacheMessage::Write {
                             account: to_account.clone(),
                             who: ActorType::AccountCache,
-                            location: "bridge_in_event test".into()
+                            location: "send_event test".into()
                         })
                         .ok()
                 ))
-            .is_some()
-    );
+            .is_some());
 
-    const TRANSFER_AMOUNT: u64 = 1;
-    let send_transaction = Transaction::test_send(
-        TRANSFER_AMOUNT,
-        from_account_address,
-        from_program_address,
-        to_account_address,
-    );
-    let res = Batcher::add_transaction_to_account(batcher, send_transaction).await;
+            const TRANSFER_AMOUNT: u64 = 1;
+            let send_transaction = Transaction::test_send(
+                TRANSFER_AMOUNT,
+                from_account_address,
+                from_account.nonce(),
+                from_program_address,
+                to_account_address,
+            );
+            let res =
+                Batcher::add_transaction_to_account(node.batcher.clone(), send_transaction).await;
 
-    let from_account_with_updates = get_account(from_account_address, ActorType::AccountCache)
+            let from_account_with_updates =
+                get_account(from_account_address, ActorType::AccountCache)
+                    .await
+                    .expect("could not find from account");
+            let to_account_with_updates = get_account(to_account_address, ActorType::AccountCache)
+                .await
+                .expect("could not find to account");
+
+            assert!(res.is_ok());
+            assert_eq!(
+                from_account_with_updates.balance(&from_program_address),
+                U256::from(from_account.balance(&from_program_address) - TRANSFER_AMOUNT)
+            );
+            assert_eq!(
+                to_account_with_updates.balance(&from_program_address),
+                U256::from(TRANSFER_AMOUNT)
+            );
+
+            MinimalNode::shutdown_and_wait(node).await
+        })
         .await
-        .expect("could not find from account");
-    let to_account_with_updates = get_account(to_account_address, ActorType::AccountCache)
-        .await
-        .expect("could not find to account");
+        .unwrap();
+}
 
-    assert!(res.is_ok());
-    assert_eq!(
-        from_account_with_updates.balance(&from_program_address),
-        U256::from(from_account.balance(&from_program_address) - TRANSFER_AMOUNT)
-    );
-    assert_eq!(
-        to_account_with_updates.balance(&from_program_address),
-        U256::from(TRANSFER_AMOUNT)
-    );
-    batcher_ref.stop_and_wait(None, None).await.ok();
-    account_cache_ref.stop_and_wait(None, None).await.ok();
-    scheduler_ref.stop_and_wait(None, None).await.ok();
-    pending_transaction_ref.stop_and_wait(None, None).await.ok();
-    std::thread::sleep(std::time::Duration::from_secs(5));
+#[serial]
+#[tokio::test]
+async fn register_program_event() {
+    MinimalNode::new()
+        .and_then(|node| async move {
+            // Insert account into storage & account cache.
+            let from_account = Account::test_default_user_account();
+            let from_account_address = from_account.owner_address();
+            assert!(
+                <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+                    &node.mock_storage,
+                    from_account.owner_address().to_full_string(),
+                    bincode::serialize(&from_account).expect("failed serialization of to account")
+                )
+                .await
+                .is_ok()
+            );
+            assert!(get_actor_ref::<AccountCacheMessage, AccountCacheError>(
+                ActorType::AccountCache
+            )
+            .and_then(|account_cache| account_cache
+                .send_message(AccountCacheMessage::Write {
+                    account: from_account.clone(),
+                    who: ActorType::AccountCache,
+                    location: "register_program_event test".into()
+                })
+                .ok())
+            .is_some());
+
+            const PROGRAM_ID: [u8; 20] = [2; 20];
+            const CONTENT_ID: &str = "test";
+            let program_id = Address::new(PROGRAM_ID);
+            let register_program_transaction = Transaction::test_register_program(
+                from_account.nonce(),
+                from_account_address,
+                program_id,
+            );
+            // The initial program_id is hashed with the transaction before being added to the cache
+            // so here we re-create that bit so we have the correct address to the check the cache.
+            let finalized_program_id = lasr_contract::create_program_id(
+                CONTENT_ID.to_string(),
+                &register_program_transaction,
+            )
+            .expect("failed to generate finalized program id");
+
+            let registration_successful = Batcher::apply_program_registration(
+                node.batcher.clone(),
+                register_program_transaction,
+            )
+            .await
+            .is_ok();
+            let program_is_registered = get_account(finalized_program_id, ActorType::AccountCache)
+                .await
+                .is_some();
+
+            assert!(registration_successful);
+            assert!(program_is_registered);
+
+            MinimalNode::shutdown_and_wait(node).await
+        })
+        .await
+        .unwrap();
+}
+
+#[serial]
+#[tokio::test]
+async fn call_create_event() {
+    MinimalNode::new()
+        .and_then(|node| async move {
+            // Insert accounts into storage & account cache.
+            // This simulates an already registered program.
+            let (from_account, from_program_account) = sender_test_account_pair();
+            let from_account_address = from_account.owner_address();
+            let AccountType::Program(from_program_address) = from_program_account.account_type()
+            else {
+                panic!("from_program_account is not a program account.")
+            };
+            assert!(
+                <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+                    &node.mock_storage,
+                    from_account_address.to_full_string(),
+                    bincode::serialize(&from_account).expect("failed serialization of to account")
+                )
+                .await
+                .is_ok()
+                    && <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+                        &node.mock_storage,
+                        from_program_address.to_full_string(),
+                        bincode::serialize(&from_program_account)
+                            .expect("failed serialization of from program account")
+                    )
+                    .await
+                    .is_ok()
+            );
+            assert!(get_actor_ref::<AccountCacheMessage, AccountCacheError>(
+                ActorType::AccountCache
+            )
+            .and_then(|account_cache| account_cache
+                .send_message(AccountCacheMessage::Write {
+                    account: from_account.clone(),
+                    who: ActorType::AccountCache,
+                    location: "call_create_event test".into()
+                })
+                .ok()
+                .zip(
+                    account_cache
+                        .send_message(AccountCacheMessage::Write {
+                            account: from_program_account,
+                            who: ActorType::AccountCache,
+                            location: "call_create_event test".into()
+                        })
+                        .ok()
+                ))
+            .is_some());
+
+            const TOKEN_AMOUNT: u64 = 1;
+            let create_transaction = Transaction::test_create(
+                from_account.nonce(),
+                from_account_address,
+                from_program_address,
+            );
+            let program_address = AddressOrNamespace::Address(from_program_address);
+            let outputs = OutputsBuilder::new()
+                .add_instruction(lasr_types::Instruction::Create(
+                    CreateInstructionBuilder::new()
+                        .program_namespace(program_address.clone())
+                        .program_id(program_address.clone())
+                        .program_owner(from_account.owner_address())
+                        .total_supply(U256::from(100))
+                        .initialized_supply(U256::from(100))
+                        .add_token_distribution(
+                            TokenDistributionBuilder::new()
+                                .program_id(program_address)
+                                .to(AddressOrNamespace::Address(from_account.owner_address()))
+                                .amount(U256::from(TOKEN_AMOUNT))
+                                .add_token_id(U256::from(100))
+                                .build()
+                                .expect("failed to create distribution"),
+                        )
+                        .build()
+                        .expect("failed to build create instruction"),
+                ))
+                .inputs(Inputs::default())
+                .build()
+                .expect("failed to build outputs");
+
+            let res = Batcher::apply_instructions_to_accounts(
+                node.batcher.clone(),
+                create_transaction,
+                outputs,
+            )
+            .await;
+
+            let from_account_with_updates =
+                get_account(from_account.owner_address(), ActorType::AccountCache)
+                    .await
+                    .unwrap();
+
+            assert!(res.is_ok());
+            // TODO: assert other expectations of token creation
+            assert_eq!(
+                from_account_with_updates.balance(&from_program_address),
+                from_account.balance(&from_program_address) + TOKEN_AMOUNT
+            );
+
+            MinimalNode::shutdown_and_wait(node).await
+        })
+        .await
+        .unwrap();
+}
+#[serial]
+#[tokio::test]
+async fn call_update_event() {
+    MinimalNode::new()
+        .and_then(|node| async move { MinimalNode::shutdown_and_wait(node).await })
+        .await
+        .unwrap();
+}
+#[serial]
+#[tokio::test]
+async fn call_transfer_event() {
+    MinimalNode::new()
+        .and_then(|node| async move { MinimalNode::shutdown_and_wait(node).await })
+        .await
+        .unwrap();
+}
+#[serial]
+#[tokio::test]
+async fn call_burn_event() {
+    MinimalNode::new()
+        .and_then(|node| async move {
+            // pub struct BurnInstructionBuilder {
+            //     pub caller: Option<Address>,
+            //     pub program_id: Option<AddressOrNamespace>,
+            //     pub token: Option<Address>,
+            //     pub from: Option<AddressOrNamespace>,
+            //     pub amount: Option<crate::U256>,
+            //     pub token_ids: Vec<crate::U256>,
+            // }
+
+            MinimalNode::shutdown_and_wait(node).await
+        })
+        .await
+        .unwrap();
 }

--- a/crates/actors/tests/account.rs
+++ b/crates/actors/tests/account.rs
@@ -6,9 +6,6 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::Ok;
-use eigenda_client::proof::BlobVerificationProof;
-use futures::TryFutureExt;
 use lasr_actors::{
     get_account, get_actor_ref, AccountCacheActor, AccountCacheError, Batcher, BatcherActor,
     PendingTransactionActor, TaskScheduler, ETH_ADDR,
@@ -31,6 +28,8 @@ use ractor::{
 };
 use serial_test::serial;
 use tokio::sync::{mpsc, Mutex};
+use eigenda_client::proof::BlobVerificationProof;
+use futures::TryFutureExt;
 
 /// This is an account with nothing in it, with `Address([1; 20])`.
 pub fn test_default_user_account() -> Account {

--- a/crates/actors/tests/account.rs
+++ b/crates/actors/tests/account.rs
@@ -1,0 +1,49 @@
+#![cfg(test)]
+//! Test events that make changes to `Account`s.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use lasr_types::{
+    Account, AccountBuilder, AccountType, Address, AddressOrNamespace, ArbitraryData, Metadata,
+    Namespace, Status, TokenBuilder, U256,
+};
+
+pub fn default_test_account(hex_address: String) -> Account {
+    let owner_address =
+        Address::from_hex(&hex_address).expect("failed to produce address from hex str");
+    let namespace = Namespace::from("TEST_NAMESPACE".to_string());
+    let program_namespace = AddressOrNamespace::Namespace(namespace);
+    let mut test_program_set = BTreeSet::new();
+    test_program_set.insert(program_namespace.clone());
+    let program_address = Address::new([4; 20]);
+    let token = TokenBuilder::default()
+        .program_id(program_address.clone())
+        .owner_id(owner_address.clone())
+        .balance(U256::from(666))
+        .metadata(Metadata::new())
+        .token_ids(vec![U256::from(69)])
+        .allowance(BTreeMap::new())
+        .approvals(BTreeMap::new())
+        .data(ArbitraryData::new())
+        .status(Status::Free)
+        .build()
+        .expect("failed to build test token");
+    let mut programs = BTreeMap::new();
+    programs.insert(program_address, token);
+    AccountBuilder::default()
+        .account_type(AccountType::User)
+        .program_namespace(Some(program_namespace))
+        .owner_address(owner_address)
+        .programs(programs)
+        .nonce(U256::from(0))
+        .program_account_data(ArbitraryData::new())
+        .program_account_metadata(Metadata::new())
+        .program_account_linked_programs(test_program_set)
+        .build()
+        .expect("failed to build test account")
+}
+
+#[test]
+fn bridge_in_event() {
+    let account = default_test_account(Address::default().to_full_string());
+}

--- a/crates/actors/tests/account.rs
+++ b/crates/actors/tests/account.rs
@@ -22,14 +22,14 @@ use lasr_types::{
     TransactionType, TransferInstructionBuilder, UpdateInstructionBuilder, U256,
 };
 
+use eigenda_client::proof::BlobVerificationProof;
+use futures::TryFutureExt;
 use ractor::{
     concurrency::{JoinHandle, OneshotReceiver},
     Actor, ActorRef,
 };
 use serial_test::serial;
 use tokio::sync::{mpsc, Mutex};
-use eigenda_client::proof::BlobVerificationProof;
-use futures::TryFutureExt;
 
 /// This is an account with nothing in it, with `Address([1; 20])`.
 pub fn test_default_user_account() -> Account {

--- a/crates/actors/tests/account.rs
+++ b/crates/actors/tests/account.rs
@@ -1,27 +1,51 @@
 #![cfg(test)]
 //! Test events that make changes to `Account`s.
 
-use std::collections::{BTreeMap, BTreeSet};
-
-use lasr_types::{
-    Account, AccountBuilder, AccountType, Address, AddressOrNamespace, ArbitraryData, Metadata,
-    Namespace, Status, TokenBuilder, U256,
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
 };
 
-pub fn default_test_account(hex_address: String) -> Account {
-    let owner_address =
-        Address::from_hex(&hex_address).expect("failed to produce address from hex str");
-    let namespace = Namespace::from("TEST_NAMESPACE".to_string());
+use lasr_actors::{
+    get_actor_ref, AccountCacheActor, AccountCacheError, Batcher, BatcherActor, TaskScheduler,
+};
+use lasr_messages::{AccountCacheMessage, ActorName, ActorType};
+use lasr_types::{
+    Account, AccountBuilder, AccountType, Address, AddressOrNamespace, ArbitraryData, Metadata,
+    MockPersistenceStore, Namespace, PersistenceStore, Status, TokenBuilder, Transaction, U256,
+};
+
+use ractor::Actor;
+use tokio::sync::Mutex;
+
+/// This is an account with nothing in it, with `Address([0; 20])`.
+/// Often this will be the `receiver_test_account`, and can be used
+/// in conjunction with the rust update syntax, e.g. `..empty_account()`.
+pub fn empty_account() -> Account {
+    Default::default()
+}
+
+/// The canonical `from` user account for testing purposes, and its program account.
+pub fn sender_test_account_pair() -> (Account, Account) {
+    const SENDER_ADDRESS: [u8; 20] = [1; 20];
+    const SENDER_PROGRAM_NAMESPACE: &str = "SENDER_PROGRAM_NAMESPACE";
+    const SENDER_PROGRAM_ADDRESS: [u8; 20] = [0; 20];
+    const STARTING_TOKEN_BALANCE: u32 = 1000;
+    const TOKEN_ID_0: u32 = 100;
+
+    let owner_address = Address::new(SENDER_ADDRESS);
+    let namespace = Namespace::from(SENDER_PROGRAM_NAMESPACE.to_string());
+
     let program_namespace = AddressOrNamespace::Namespace(namespace);
     let mut test_program_set = BTreeSet::new();
     test_program_set.insert(program_namespace.clone());
-    let program_address = Address::new([4; 20]);
+    let program_address = Address::new(SENDER_PROGRAM_ADDRESS);
     let token = TokenBuilder::default()
         .program_id(program_address.clone())
         .owner_id(owner_address.clone())
-        .balance(U256::from(666))
+        .balance(U256::from(STARTING_TOKEN_BALANCE))
         .metadata(Metadata::new())
-        .token_ids(vec![U256::from(69)])
+        .token_ids(vec![U256::from(TOKEN_ID_0)])
         .allowance(BTreeMap::new())
         .approvals(BTreeMap::new())
         .data(ArbitraryData::new())
@@ -30,20 +54,111 @@ pub fn default_test_account(hex_address: String) -> Account {
         .expect("failed to build test token");
     let mut programs = BTreeMap::new();
     programs.insert(program_address, token);
-    AccountBuilder::default()
-        .account_type(AccountType::User)
-        .program_namespace(Some(program_namespace))
-        .owner_address(owner_address)
-        .programs(programs)
-        .nonce(U256::from(0))
-        .program_account_data(ArbitraryData::new())
-        .program_account_metadata(Metadata::new())
-        .program_account_linked_programs(test_program_set)
-        .build()
-        .expect("failed to build test account")
+
+    (
+        AccountBuilder::default()
+            .account_type(AccountType::User)
+            .program_namespace(Some(program_namespace.clone()))
+            .owner_address(owner_address)
+            .programs(programs)
+            .nonce(U256::from(0))
+            .program_account_data(ArbitraryData::new())
+            .program_account_metadata(Metadata::new())
+            .program_account_linked_programs(test_program_set)
+            .build()
+            .expect("failed to build test user account"),
+        AccountBuilder::default()
+            .account_type(AccountType::Program(program_address))
+            .program_namespace(Some(program_namespace))
+            .owner_address(owner_address)
+            .programs(BTreeMap::new())
+            .nonce(U256::from(0))
+            .program_account_data(ArbitraryData::new())
+            .program_account_metadata(Metadata::new())
+            .program_account_linked_programs(BTreeSet::new())
+            .build()
+            .expect("failed to build test program account"),
+    )
 }
 
-#[test]
-fn bridge_in_event() {
-    let account = default_test_account(Address::default().to_full_string());
+#[tokio::test]
+async fn bridge_in_event() {
+    // Channel is not used, but is necessary to construct a `Batcher` and cannot be zero.
+    const CHANNEL_BUFFER: usize = 1;
+    let (receivers_thread_tx, _receivers_thread_rx) = tokio::sync::mpsc::channel(CHANNEL_BUFFER);
+
+    let mock_storage = <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::new()
+        .await
+        .expect("failed to create mock persistence storage");
+
+    // Insert accounts into storage & account cache
+    let (from_account, from_program_account) = sender_test_account_pair();
+    assert!(
+        <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+            &mock_storage,
+            from_account.owner_address().to_full_string(),
+            bincode::serialize(&from_account)
+                .expect("failed serialization of from address for bridge in event")
+        )
+        .await
+        .is_ok()
+            && <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+                &mock_storage,
+                from_program_account.owner_address().to_full_string(),
+                bincode::serialize(&from_program_account)
+                    .expect("failed serialization of from address for bridge in event")
+            )
+            .await
+            .is_ok()
+    );
+    let account_cache_actor = AccountCacheActor::new();
+    let (_account_cache_ref, _account_cache_handle) = Actor::spawn(
+        Some(account_cache_actor.name()),
+        account_cache_actor,
+        mock_storage,
+    )
+    .await
+    .expect("failed to spawn account cache actor");
+    assert!(
+        get_actor_ref::<AccountCacheMessage, AccountCacheError>(ActorType::AccountCache)
+            .and_then(|account_cache| account_cache
+                .send_message(AccountCacheMessage::Write {
+                    account: from_account,
+                    who: ActorType::AccountCache,
+                    location: "bridge_in_event test".into(),
+                })
+                .ok()
+                .zip(
+                    account_cache
+                        .send_message(AccountCacheMessage::Write {
+                            account: from_program_account,
+                            who: ActorType::AccountCache,
+                            location: "bridge_in_event test".into()
+                        })
+                        .ok()
+                ))
+            .is_some()
+    );
+
+    let scheduler_actor = TaskScheduler::new();
+    let (_scheduler_ref, _scheduler_handle) =
+        Actor::spawn(Some(scheduler_actor.name()), scheduler_actor, ())
+            .await
+            .expect("failed to spawn scheduler actor");
+
+    let batcher_actor = BatcherActor::new();
+    let batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
+    let (_batcher_ref, _batcher_handle) =
+        Actor::spawn(Some(batcher_actor.name()), batcher_actor, batcher.clone())
+            .await
+            .expect("failed to spawn batcher actor");
+
+    let to_account = empty_account();
+
+    const BRIDGE_IN_AMOUNT: u64 = 1;
+    let bridge_transaction = Transaction::bridge_in(BRIDGE_IN_AMOUNT, to_account.owner_address());
+    let res = Batcher::add_transaction_to_account(batcher, bridge_transaction).await;
+    dbg!(&res);
+
+    assert!(res.is_ok());
 }

--- a/crates/actors/tests/account.rs
+++ b/crates/actors/tests/account.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use lasr_actors::{
-    get_actor_ref, AccountCacheActor, AccountCacheError, Batcher, BatcherActor,
-    PendingTransactionActor, TaskScheduler,
+    get_account, get_actor_ref, AccountCacheActor, AccountCacheError, Batcher, BatcherActor,
+    PendingTransactionActor, TaskScheduler, ETH_ADDR,
 };
 use lasr_messages::{AccountCacheMessage, ActorName, ActorType};
 use lasr_types::{
@@ -17,26 +17,24 @@ use lasr_types::{
 };
 
 use ractor::Actor;
+use serial_test::serial;
 use tokio::sync::Mutex;
 
-/// This is an account with nothing in it, with `Address([0; 20])`.
-/// Often this will be the `receiver_test_account`, and can be used
-/// in conjunction with the rust update syntax, e.g. `..empty_account()`.
-pub fn empty_account() -> Account {
-    Default::default()
+/// This is an account with nothing in it, with `Address([1; 20])`.
+pub fn receiver_test_account() -> Account {
+    Account::test_default_user_account()
 }
 
 /// The canonical `from` user account for testing purposes, and its program account.
 pub fn sender_test_account_pair() -> (Account, Account) {
-    const SENDER_ADDRESS: [u8; 20] = [1; 20];
+    const SENDER_ADDRESS: [u8; 20] = [2; 20];
     const SENDER_PROGRAM_NAMESPACE: &str = "SENDER_PROGRAM_NAMESPACE";
-    const SENDER_PROGRAM_ADDRESS: [u8; 20] = [2; 20];
+    const SENDER_PROGRAM_ADDRESS: [u8; 20] = [3; 20];
     const STARTING_TOKEN_BALANCE: u32 = 1000;
     const TOKEN_ID_0: u32 = 100;
 
     let owner_address = Address::new(SENDER_ADDRESS);
     let namespace = Namespace::from(SENDER_PROGRAM_NAMESPACE.to_string());
-
     let program_namespace = AddressOrNamespace::Namespace(namespace);
     let mut test_program_set = BTreeSet::new();
     test_program_set.insert(program_namespace.clone());
@@ -82,6 +80,7 @@ pub fn sender_test_account_pair() -> (Account, Account) {
     )
 }
 
+#[serial]
 #[tokio::test]
 async fn bridge_in_event() {
     // Channel is not used, but is necessary to construct a `Batcher` and cannot be zero.
@@ -89,7 +88,7 @@ async fn bridge_in_event() {
     let (receivers_thread_tx, _receivers_thread_rx) = tokio::sync::mpsc::channel(CHANNEL_BUFFER);
     let batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
     let batcher_actor = BatcherActor::new();
-    let (_batcher_ref, _batcher_handle) =
+    let (batcher_ref, _batcher_handle) =
         Actor::spawn(Some(batcher_actor.name()), batcher_actor, batcher.clone())
             .await
             .expect("failed to spawn batcher actor");
@@ -98,7 +97,7 @@ async fn bridge_in_event() {
         .await
         .expect("failed to create mock persistence storage");
     let account_cache_actor = AccountCacheActor::new();
-    let (_account_cache_ref, _account_cache_handle) = Actor::spawn(
+    let (account_cache_ref, _account_cache_handle) = Actor::spawn(
         Some(account_cache_actor.name()),
         account_cache_actor,
         mock_storage.clone(),
@@ -107,13 +106,13 @@ async fn bridge_in_event() {
     .expect("failed to spawn account cache actor");
 
     let scheduler_actor = TaskScheduler::new();
-    let (_scheduler_ref, _scheduler_handle) =
+    let (scheduler_ref, _scheduler_handle) =
         Actor::spawn(Some(scheduler_actor.name()), scheduler_actor, ())
             .await
             .expect("failed to spawn scheduler actor");
 
     let pending_transaction_actor = PendingTransactionActor::new();
-    let (_pending_transaction_ref, _pending_transaction_handle) = Actor::spawn(
+    let (pending_transaction_ref, _pending_transaction_handle) = Actor::spawn(
         Some(pending_transaction_actor.name()),
         pending_transaction_actor,
         (),
@@ -121,17 +120,106 @@ async fn bridge_in_event() {
     .await
     .expect("failed to spawn pending transaction actor");
 
-    // Insert from accounts into storage & account cache
+    // Insert account into storage & account cache.
+    let to_account = receiver_test_account();
+    let to_account_address = to_account.owner_address();
+    assert!(
+        <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+            &mock_storage,
+            to_account.owner_address().to_full_string(),
+            bincode::serialize(&to_account).expect("failed serialization of to address")
+        )
+        .await
+        .is_ok()
+    );
+    assert!(
+        get_actor_ref::<AccountCacheMessage, AccountCacheError>(ActorType::AccountCache)
+            .and_then(|account_cache| account_cache
+                .send_message(AccountCacheMessage::Write {
+                    account: to_account.clone(),
+                    who: ActorType::AccountCache,
+                    location: "bridge_in_event test".into()
+                })
+                .ok())
+            .is_some()
+    );
+
+    const BRIDGE_IN_AMOUNT: u64 = 1;
+    let program_id = ETH_ADDR;
+    let bridge_in_transaction =
+        Transaction::test_bridge_in(BRIDGE_IN_AMOUNT, program_id, to_account_address);
+    let res = Batcher::add_transaction_to_account(batcher, bridge_in_transaction).await;
+
+    let to_account_with_updates = get_account(to_account_address, ActorType::AccountCache)
+        .await
+        .expect("could not find to account");
+
+    assert!(res.is_ok());
+    assert_eq!(
+        to_account_with_updates.balance(&program_id),
+        U256::from(BRIDGE_IN_AMOUNT)
+    );
+    batcher_ref.stop_and_wait(None, None).await.ok();
+    account_cache_ref.stop_and_wait(None, None).await.ok();
+    scheduler_ref.stop_and_wait(None, None).await.ok();
+    pending_transaction_ref.stop_and_wait(None, None).await.ok();
+    std::thread::sleep(std::time::Duration::from_secs(5));
+}
+
+#[serial]
+#[tokio::test]
+async fn send_event() {
+    // Channel is not used, but is necessary to construct a `Batcher` and cannot be zero.
+    const CHANNEL_BUFFER: usize = 1;
+    let (receivers_thread_tx, _receivers_thread_rx) = tokio::sync::mpsc::channel(CHANNEL_BUFFER);
+    let batcher = Arc::new(Mutex::new(Batcher::new(receivers_thread_tx)));
+    let batcher_actor = BatcherActor::new();
+    let (batcher_ref, _batcher_handle) =
+        Actor::spawn(Some(batcher_actor.name()), batcher_actor, batcher.clone())
+            .await
+            .expect("failed to spawn batcher actor");
+
+    let mock_storage = <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::new()
+        .await
+        .expect("failed to create mock persistence storage");
+    let account_cache_actor = AccountCacheActor::new();
+    let (account_cache_ref, _account_cache_handle) = Actor::spawn(
+        Some(account_cache_actor.name()),
+        account_cache_actor,
+        mock_storage.clone(),
+    )
+    .await
+    .expect("failed to spawn account cache actor");
+
+    let scheduler_actor = TaskScheduler::new();
+    let (scheduler_ref, _scheduler_handle) =
+        Actor::spawn(Some(scheduler_actor.name()), scheduler_actor, ())
+            .await
+            .expect("failed to spawn scheduler actor");
+
+    let pending_transaction_actor = PendingTransactionActor::new();
+    let (pending_transaction_ref, _pending_transaction_handle) = Actor::spawn(
+        Some(pending_transaction_actor.name()),
+        pending_transaction_actor,
+        (),
+    )
+    .await
+    .expect("failed to spawn pending transaction actor");
+
+    // Insert accounts into storage & account cache.
+    // This simulates an already registered program.
     let (from_account, from_program_account) = sender_test_account_pair();
+    let from_account_address = from_account.owner_address();
     let AccountType::Program(from_program_address) = from_program_account.account_type() else {
         panic!("from_program_account is not a program account.")
     };
+    let to_account = receiver_test_account();
+    let to_account_address = to_account.owner_address();
     assert!(
         <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
             &mock_storage,
             from_account.owner_address().to_full_string(),
-            bincode::serialize(&from_account)
-                .expect("failed serialization of from address for bridge in event")
+            bincode::serialize(&from_account).expect("failed serialization of from address")
         )
         .await
         .is_ok()
@@ -139,7 +227,14 @@ async fn bridge_in_event() {
                 &mock_storage,
                 from_program_account.owner_address().to_full_string(),
                 bincode::serialize(&from_program_account)
-                    .expect("failed serialization of from address for bridge in event")
+                    .expect("failed serialization of from program address")
+            )
+            .await
+            .is_ok()
+            && <MockPersistenceStore<String, Vec<u8>> as PersistenceStore>::put(
+                &mock_storage,
+                to_account.owner_address().to_full_string(),
+                bincode::serialize(&to_account).expect("failed serialization of to address")
             )
             .await
             .is_ok()
@@ -161,32 +256,47 @@ async fn bridge_in_event() {
                             location: "bridge_in_event test".into()
                         })
                         .ok()
+                )
+                .zip(
+                    account_cache
+                        .send_message(AccountCacheMessage::Write {
+                            account: to_account.clone(),
+                            who: ActorType::AccountCache,
+                            location: "bridge_in_event test".into()
+                        })
+                        .ok()
                 ))
             .is_some()
     );
 
-    let to_account = empty_account();
-
-    const BRIDGE_IN_AMOUNT: u64 = 1;
-    let bridge_in_transaction = Transaction::bridge_in(
-        BRIDGE_IN_AMOUNT,
-        from_account.owner_address(),
+    const TRANSFER_AMOUNT: u64 = 1;
+    let send_transaction = Transaction::test_send(
+        TRANSFER_AMOUNT,
+        from_account_address,
         from_program_address,
-        to_account.owner_address(),
+        to_account_address,
     );
-    let res = Batcher::add_transaction_to_account(batcher, bridge_in_transaction).await;
+    let res = Batcher::add_transaction_to_account(batcher, send_transaction).await;
+
+    let from_account_with_updates = get_account(from_account_address, ActorType::AccountCache)
+        .await
+        .expect("could not find from account");
+    let to_account_with_updates = get_account(to_account_address, ActorType::AccountCache)
+        .await
+        .expect("could not find to account");
 
     assert!(res.is_ok());
-    assert_eq!(from_account.balance(&from_program_address), U256::from(999));
     assert_eq!(
-        to_account.balance(&Default::default()),
-        U256::from(BRIDGE_IN_AMOUNT)
+        from_account_with_updates.balance(&from_program_address),
+        U256::from(from_account.balance(&from_program_address) - TRANSFER_AMOUNT)
     );
-    // drop all actors, not strictly necessary.
-    let (_, _, _, _) = (
-        _batcher_handle,
-        _account_cache_handle,
-        _scheduler_handle,
-        _pending_transaction_handle,
+    assert_eq!(
+        to_account_with_updates.balance(&from_program_address),
+        U256::from(TRANSFER_AMOUNT)
     );
+    batcher_ref.stop_and_wait(None, None).await.ok();
+    account_cache_ref.stop_and_wait(None, None).await.ok();
+    scheduler_ref.stop_and_wait(None, None).await.ok();
+    pending_transaction_ref.stop_and_wait(None, None).await.ok();
+    std::thread::sleep(std::time::Duration::from_secs(5));
 }

--- a/crates/compute/src/compute.rs
+++ b/crates/compute/src/compute.rs
@@ -10,7 +10,7 @@ use std::os::unix::prelude::PermissionsExt;
 use std::path::Path;
 use std::process::Stdio;
 use std::{ffi::OsStr, fmt::Display};
-use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
 use web3_pkg::web3_store::Web3Store;
 

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -3,7 +3,9 @@ name = "lasr_messages"
 version = "0.9.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["mock_storage"]
+mock_storage = []
 
 [dependencies]
 uuid = { version = "1.3", features = ["v4", "serde"] }

--- a/crates/messages/src/messages.rs
+++ b/crates/messages/src/messages.rs
@@ -12,6 +12,7 @@ use ractor::RpcReplyPort;
 use ractor_cluster::RactorMessage;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
+#[cfg(not(feature = "mock_storage"))]
 use tikv_client::RawClient as TikvClient;
 use web3::ethabi::{Address as EthereumAddress, FixedBytes};
 use web3::types::TransactionReceipt;
@@ -448,7 +449,10 @@ pub enum BatcherMessage {
         outputs: Option<Outputs>,
     },
     GetNextBatch {
-        tikv_client: TikvClient,
+        #[cfg(not(feature = "mock_storage"))]
+        storage_ref: TikvClient,
+        #[cfg(feature = "mock_storage")]
+        storage_ref: lasr_types::MockPersistenceStore<String, Vec<u8>>,
     },
     BlobVerificationProof {
         request_id: String,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["local"]
+default = ["local", "mock_storage"]
 local = []
 remote = []
+mock_storage = []
 
 [[bin]]
 name = "lasr_node"

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -26,3 +26,5 @@ log = "0.4.20"
 typetag = "0.2.14"
 uint = "0.9.5"
 schemars = "0.8.16"
+tikv-client = "0.3.0"
+tokio = { version = "1.34.0", features = ["full"] }

--- a/crates/types/src/account.rs
+++ b/crates/types/src/account.rs
@@ -1053,16 +1053,6 @@ impl Account {
     }
 }
 
-impl Account {
-    pub fn test_default_user_account() -> Self {
-        Self {
-            account_type: AccountType::User,
-            owner_address: Address::new([1; 20]),
-            ..Default::default()
-        }
-    }
-}
-
 impl Display for Address {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let hex_str: String = self.encode_hex();

--- a/crates/types/src/account.rs
+++ b/crates/types/src/account.rs
@@ -290,10 +290,11 @@ impl ProgramAccount {
 }
 
 #[derive(
-    Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash,
+    Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash, Default,
 )]
 #[serde(rename_all = "camelCase")]
 pub enum AccountType {
+    #[default]
     User,
     Program(Address),
 }
@@ -304,7 +305,18 @@ pub enum AccountType {
 /// programs, nonce, signatures, hashes, and certificates. It implements traits for
 /// serialization, hashing, and comparison.
 #[derive(
-    Builder, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash,
+    Builder,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Default,
 )]
 #[serde(rename_all = "camelCase")]
 pub struct Account {

--- a/crates/types/src/account.rs
+++ b/crates/types/src/account.rs
@@ -87,7 +87,7 @@ impl<'de> Deserialize<'de> for Address {
 /// This structure is used to store Ethereum Compatible addresses, which are
 /// derived from the public key. It implements traits like Clone, Copy, Debug,
 /// Serialize, Deserialize, etc., for ease of use across various contexts.
-#[derive(Clone, Copy, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, JsonSchema, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Address([u8; 20]);
 

--- a/crates/types/src/account.rs
+++ b/crates/types/src/account.rs
@@ -1053,6 +1053,16 @@ impl Account {
     }
 }
 
+impl Account {
+    pub fn test_default_user_account() -> Self {
+        Self {
+            account_type: AccountType::User,
+            owner_address: Address::new([1; 20]),
+            ..Default::default()
+        }
+    }
+}
+
 impl Display for Address {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let hex_str: String = self.encode_hex();

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod account;
+pub mod persistence;
 pub mod programming_model;
 pub mod signing;
 pub mod token;
 pub mod transaction;
 
 pub use account::*;
+pub use persistence::*;
 pub use programming_model::*;
 pub use signing::*;
 pub use token::*;

--- a/crates/types/src/persistence.rs
+++ b/crates/types/src/persistence.rs
@@ -1,4 +1,10 @@
 #![allow(async_fn_in_trait)]
+//! Persistent storage types used in the protocol, or for testing means.
+//! The main export of this module is the `PersistenceStore` trait, which
+//! is used for generalizing access to some storage either for production
+//! or in-memory key-value storage, and works in tandem with `ractor::Actor`.
+//!
+//! TL;DR allows using `HashMap` for storage in tests.
 
 /// Drop in replacement trait for subbing out storage types where
 /// they would otherwise be inconvenient.

--- a/crates/types/src/persistence.rs
+++ b/crates/types/src/persistence.rs
@@ -1,0 +1,90 @@
+#![allow(async_fn_in_trait)]
+
+/// Drop in replacement trait for subbing out storage types where
+/// they would otherwise be inconvenient.
+///
+/// NOTE: It's probably best to use these methods as trait methods
+/// to avoid collisions with the already implemented `get` & `put`.
+///
+/// ## Example:
+/// ```rust,ignore
+/// PersistenceStore::get(&store, key).await.unwrap();
+/// ```
+pub trait PersistenceStore: Clone {
+    type Myself;
+    type Key;
+    type Value;
+    type Error;
+
+    async fn new() -> Result<Self::Myself, Self::Error>;
+
+    async fn get(&self, key: Self::Key) -> Result<Option<Self::Value>, Self::Error>;
+
+    async fn put(&self, key: Self::Key, val: Self::Value) -> Result<(), Self::Error>;
+}
+
+impl PersistenceStore for tikv_client::RawClient {
+    type Myself = tikv_client::RawClient;
+    type Key = tikv_client::Key;
+    type Value = tikv_client::Value;
+    type Error = tikv_client::Error;
+
+    async fn new() -> Result<Self, Self::Error> {
+        const TIKV_CLIENT_PD_ENDPOINT: &str = "127.0.0.1:2379";
+        tikv_client::RawClient::new(vec![TIKV_CLIENT_PD_ENDPOINT]).await
+    }
+
+    async fn get(&self, key: Self::Key) -> Result<Option<Self::Value>, Self::Error> {
+        tikv_client::RawClient::get(self, key).await
+    }
+
+    async fn put(&self, key: Self::Key, val: Self::Value) -> Result<(), Self::Error> {
+        tikv_client::RawClient::put(self, key, val).await
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PersistenceStoreError {
+    #[error("value not found in persistence store")]
+    ValueNotFound,
+}
+
+/// About as close as it gets to persistence.. without persistence.
+#[derive(Clone)]
+pub struct MockPersistenceStore<K, V>(
+    std::sync::Arc<tokio::sync::Mutex<std::collections::HashMap<K, V>>>,
+)
+where
+    K: std::cmp::Eq + std::hash::Hash + Clone,
+    V: Clone;
+
+impl<K, V> PersistenceStore for MockPersistenceStore<K, V>
+where
+    K: std::cmp::Eq + std::hash::Hash + Clone,
+    V: Clone,
+{
+    type Myself = MockPersistenceStore<K, V>;
+    type Key = K;
+    type Value = V;
+    type Error = PersistenceStoreError;
+
+    async fn new() -> Result<Self::Myself, Self::Error> {
+        Ok(MockPersistenceStore(std::sync::Arc::new(
+            tokio::sync::Mutex::new(std::collections::HashMap::new()),
+        )))
+    }
+
+    async fn get(&self, key: Self::Key) -> Result<Option<Self::Value>, Self::Error> {
+        let map = self.0.lock().await;
+        match map.get(&key) {
+            Some(value) => Ok(Some(value.clone())),
+            None => Err(PersistenceStoreError::ValueNotFound),
+        }
+    }
+
+    async fn put(&self, key: Self::Key, val: Self::Value) -> Result<(), Self::Error> {
+        let mut map = self.0.lock().await;
+        map.insert(key, val);
+        Ok(())
+    }
+}

--- a/crates/types/src/programming_model.rs
+++ b/crates/types/src/programming_model.rs
@@ -28,7 +28,7 @@ use std::{
 /// with either JSON helper functions and/or custom JSON parsing. The developer
 /// has the flexibility to do with the `Inputs`, represented by JSON as they
 /// choose.
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(
     rename(serialize = "computeInputs", deserialize = "computeInputs"),
     rename_all = "camelCase"

--- a/crates/types/src/token.rs
+++ b/crates/types/src/token.rs
@@ -208,6 +208,10 @@ impl Metadata {
         Self(BTreeMap::new())
     }
 
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.0.get(key)
+    }
+
     pub fn extend(&mut self, iter: BTreeMap<String, String>) {
         self.0.extend(iter);
     }

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -301,14 +301,12 @@ pub struct Transaction {
 
 impl Transaction {
     /// A test bridge in transaction.
-    pub fn bridge_in(amount: u64, to: Address) -> Self {
-        const SENDER_ADDRESS: [u8; 20] = [1; 20];
-        const SENDER_PROGRAM_ADDRESS: [u8; 20] = [0; 20];
+    pub fn bridge_in(amount: u64, from: Address, program_id: Address, to: Address) -> Self {
         let bridge_value = crate::U256::from(amount);
         Self {
             transaction_type: TransactionType::BridgeIn(bridge_value),
-            from: SENDER_ADDRESS, // this is the default sender for testing
-            program_id: SENDER_PROGRAM_ADDRESS, // this is the default sender program for testing
+            from: from.inner(),
+            program_id: program_id.inner(),
             to: to.inner(),
             value: bridge_value,
             ..Default::default()

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -299,27 +299,73 @@ pub struct Transaction {
     s: [u8; 32],
 }
 
+/// TEST TRANSACTIONS
 impl Transaction {
     /// A test bridge in transaction.
-    pub fn test_bridge_in(amount: u64, program_id: Address, to: Address) -> Self {
-        let bridge_value = crate::U256::from(amount);
+    pub fn test_bridge_in(
+        amount: u64,
+        nonce: crate::U256,
+        program_id: Address,
+        to: Address,
+    ) -> Self {
         Self {
-            transaction_type: TransactionType::BridgeIn(bridge_value),
+            transaction_type: TransactionType::BridgeIn(nonce),
             from: to.inner(),
             program_id: program_id.inner(),
             to: to.inner(),
-            value: bridge_value,
+            value: crate::U256::from(amount),
             ..Default::default()
         }
     }
-    pub fn test_send(amount: u64, from: Address, program_id: Address, to: Address) -> Self {
-        let bridge_value = crate::U256::from(amount);
+    /// A test send transaction.
+    pub fn test_send(
+        amount: u64,
+        from: Address,
+        nonce: crate::U256,
+        program_id: Address,
+        to: Address,
+    ) -> Self {
         Self {
-            transaction_type: TransactionType::Send(bridge_value),
+            transaction_type: TransactionType::Send(nonce),
             from: from.inner(),
             program_id: program_id.inner(),
             to: to.inner(),
-            value: bridge_value,
+            value: crate::U256::from(amount),
+            r: [0u8; 32],
+            s: [0u8; 32],
+            ..Default::default()
+        }
+    }
+    pub fn test_register_program(nonce: crate::U256, from: Address, program_id: Address) -> Self {
+        let payload = PayloadBuilder::default()
+            .transaction_type(TransactionType::RegisterProgram(nonce))
+            .from(from.into())
+            .to(from.into())
+            .program_id(program_id.into())
+            .inputs(String::from("{ \"contentId\": \"test\"}"))
+            .op(String::new())
+            .value(crate::U256::from(0))
+            .nonce(nonce)
+            .build()
+            .expect("failed to build payload");
+
+        let msg = secp256k1::Message::from_digest_slice(&payload.hash())
+            .expect("failed to create Message from payload");
+
+        let secp = secp256k1::Secp256k1::new();
+        let keypair = secp.generate_keypair(&mut secp256k1::rand::rngs::OsRng);
+
+        let sig: RecoverableSignature = secp.sign_ecdsa_recoverable(&msg, &keypair.0).into();
+
+        (payload, sig.clone()).into()
+    }
+    pub fn test_create(nonce: crate::U256, from: Address, program_id: Address) -> Self {
+        Self {
+            transaction_type: TransactionType::Call(nonce),
+            from: from.inner(),
+            to: from.inner(),
+            program_id: program_id.inner(),
+            nonce,
             ..Default::default()
         }
     }

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -359,11 +359,11 @@ impl Transaction {
 
         (payload, sig.clone()).into()
     }
-    pub fn test_create(nonce: crate::U256, from: Address, program_id: Address) -> Self {
+    pub fn test_call(nonce: crate::U256, from: Address, to: Address, program_id: Address) -> Self {
         Self {
             transaction_type: TransactionType::Call(nonce),
             from: from.inner(),
-            to: from.inner(),
+            to: to.inner(),
             program_id: program_id.inner(),
             nonce,
             ..Default::default()

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -299,6 +299,23 @@ pub struct Transaction {
     s: [u8; 32],
 }
 
+impl Transaction {
+    /// A test bridge in transaction.
+    pub fn bridge_in(amount: u64, to: Address) -> Self {
+        const SENDER_ADDRESS: [u8; 20] = [1; 20];
+        const SENDER_PROGRAM_ADDRESS: [u8; 20] = [0; 20];
+        let bridge_value = crate::U256::from(amount);
+        Self {
+            transaction_type: TransactionType::BridgeIn(bridge_value),
+            from: SENDER_ADDRESS, // this is the default sender for testing
+            program_id: SENDER_PROGRAM_ADDRESS, // this is the default sender program for testing
+            to: to.inner(),
+            value: bridge_value,
+            ..Default::default()
+        }
+    }
+}
+
 impl Default for Transaction {
     fn default() -> Self {
         Self {

--- a/crates/types/src/transaction.rs
+++ b/crates/types/src/transaction.rs
@@ -301,10 +301,21 @@ pub struct Transaction {
 
 impl Transaction {
     /// A test bridge in transaction.
-    pub fn bridge_in(amount: u64, from: Address, program_id: Address, to: Address) -> Self {
+    pub fn test_bridge_in(amount: u64, program_id: Address, to: Address) -> Self {
         let bridge_value = crate::U256::from(amount);
         Self {
             transaction_type: TransactionType::BridgeIn(bridge_value),
+            from: to.inner(),
+            program_id: program_id.inner(),
+            to: to.inner(),
+            value: bridge_value,
+            ..Default::default()
+        }
+    }
+    pub fn test_send(amount: u64, from: Address, program_id: Address, to: Address) -> Self {
+        let bridge_value = crate::U256::from(amount);
+        Self {
+            transaction_type: TransactionType::Send(bridge_value),
             from: from.inner(),
             program_id: program_id.inner(),
             to: to.inner(),


### PR DESCRIPTION
Closes #205 

Adds the tests necessary to prove events that update `Account` function as intended. Also adds the ability to test with in-memory key-value storage (`HashMap`) which relieves the overhead of needing a `tikv_client` running. The `MinimalNode` testing type can eventually be moved to its own module and expanded upon if needed, which makes testing node processes outside of RPC calls, IPFS and other compute related stuff (outside of the scope of these tests) relatively easy.