### PR TITLE
Abstract & Update logic in `Batcher::add_transaction_to_account()`

### DIFF
--- a/crates/actors/src/batcher.rs
+++ b/crates/actors/src/batcher.rs
@@ -437,7 +437,7 @@ impl Batcher {
         Ok(())
     }
 
-    // Applies txn token data for `BridgeIn` events & `from` account's for `Send` events.
+    // Applies txn token data for `BridgeIn` event & `from` account for `Send` event.
     pub async fn handle_bridge_send_txn(
         batch_buffer: &mut HashMap<String, Account>,
         transaction: &Transaction,
@@ -706,7 +706,9 @@ impl Batcher {
             transaction.from(),
             transaction
         );
+        // Handles token update for either `BridgeIn` event or the `from` account used in a `Send` event.
         let token = Self::handle_bridge_send_txn(&mut batch_buffer, &transaction).await?;
+        // Handles account token updates for the `to` account used in a `Send` event.
         Self::handle_to_send_txn(&mut batch_buffer, &transaction).await;
 
         for (_, account) in batch_buffer {


### PR DESCRIPTION
Closes #222 
Add's two new fns to handle the logic previously stored in `add_transaction_to_account()`.
- First handles `token` updates for `BridgeIn` event & for `from` acct involved in `Send` event
- Second only is called for `Send` events, and handles `token` updates for `to` acct involved

Removes redundant logic for `ETH_ADDR` & `VERSE_ADDR` since the two are in persistence, and the logic is never reached.
If we want specific logging for these, I can rewrite the logic to `match` for them rather than having them in `if else` statements. Otherwise I don't see the need for it.