### PR TITLE
Rework `remote` & `local` features

### DIFF
--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -6,8 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["local"]
-local = []
 remote = []
 mock_storage = []
 

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = []
 remote = []
 mock_storage = []
 

--- a/crates/actors/src/engine.rs
+++ b/crates/actors/src/engine.rs
@@ -248,7 +248,7 @@ impl EngineActor {
         }
         .to_string();
 
-        #[cfg(feature = "local")]
+        #[cfg(not(feature = "remote"))]
         let message = ExecutorMessage::Create {
             transaction: transaction.clone(),
             content_id: content_id.clone(),

--- a/crates/actors/src/executor.rs
+++ b/crates/actors/src/executor.rs
@@ -8,7 +8,7 @@ use internal_rpc::api::InternalRpcApiClient;
 #[cfg(feature = "remote")]
 use internal_rpc::job_queue::job::{ComputeJobExecutionType, ServiceJobState, ServiceJobType};
 use jsonrpsee::{core::client::ClientT, ws_client::WsClient};
-#[cfg(feature = "local")]
+#[cfg(not(feature = "remote"))]
 use lasr_compute::OciManager;
 use lasr_contract::create_program_id;
 use lasr_messages::{ActorName, BatcherMessage, SupervisorType};
@@ -74,7 +74,7 @@ pub struct DynCache;
 
 #[allow(unused)]
 pub struct ExecutionEngine<C: InternalRpcApiClient> {
-    #[cfg(feature = "local")]
+    #[cfg(not(feature = "remote"))]
     manager: OciManager,
     #[cfg(feature = "remote")]
     compute_rpc_client: C,
@@ -84,7 +84,7 @@ pub struct ExecutionEngine<C: InternalRpcApiClient> {
     pending: HashMap<uuid::Uuid, PendingJob>,
     handles: HashMap<(String, String), tokio::task::JoinHandle<std::io::Result<String>>>,
     cache: DynCache,
-    #[cfg(feature = "local")]
+    #[cfg(not(feature = "remote"))]
     phantom: std::marker::PhantomData<C>,
 }
 
@@ -136,7 +136,7 @@ impl<C: InternalRpcApiClient> ExecutionEngine<C> {
     }
 }
 
-#[cfg(feature = "local")]
+#[cfg(not(feature = "remote"))]
 impl<C: ClientT> ExecutionEngine<C> {
     pub fn new(manager: OciManager) -> Self {
         Self {
@@ -306,7 +306,7 @@ impl ExecutorActor {
         Ok(())
     }
 
-    #[cfg(feature = "local")]
+    #[cfg(not(feature = "remote"))]
     fn registration_success(transaction: Transaction) -> std::io::Result<()> {
         let actor: ActorRef<BatcherMessage> =
             ractor::registry::where_is(ActorType::Batcher.to_string())
@@ -699,7 +699,7 @@ impl ExecutorActor {
     }
 }
 
-#[cfg(feature = "local")]
+#[cfg(not(feature = "remote"))]
 #[async_trait]
 impl Actor for ExecutorActor {
     type Msg = ExecutorMessage;

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["local"]
-local = []
+default = []
 remote = []
 
 [[bin]]

--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["local"]
-local = []
+default = []
 remote = []
 
 [dependencies]

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["local"]
-local = []
+default = []
 remote = []
 mock_storage = []
 
@@ -33,8 +32,8 @@ jsonrpsee = { version = "0.22.5", features = [
   "http-client",
   "ws-client",
 ] }
-lasr_actors = { path = "../actors", features = ["local"] }
-lasr_compute = { path = "../compute", features = ["local"] }
+lasr_actors = { path = "../actors" }
+lasr_compute = { path = "../compute" }
 lasr_messages = { path = "../messages" }
 lasr_rpc = { path = "../rpc" }
 lasr_types = { path = "../types" }

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await
     .map_err(Box::new)?;
 
-    #[cfg(feature = "local")]
+    #[cfg(not(feature = "remote"))]
     let bundler: OciBundler<String, String> = OciBundlerBuilder::default()
         .runtime("/usr/local/bin/runsc".to_string())
         .base_images("./base_image".to_string())
@@ -106,10 +106,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .payload_path("./payload".to_string())
         .build()?;
 
-    #[cfg(feature = "local")]
+    #[cfg(not(feature = "remote"))]
     let oci_manager = OciManager::new(bundler, env.vipfs_address.clone());
 
-    #[cfg(feature = "local")]
+    #[cfg(not(feature = "remote"))]
     let execution_engine = Arc::new(Mutex::new(ExecutionEngine::new(oci_manager)));
 
     #[cfg(feature = "remote")]


### PR DESCRIPTION
Closes #220 
Instead of using the `local` feature as default & as an off switch for the `remote` feature, removes the extra feature entirely.
Replacing the `local` feature calls with `#[cfg(not(feature = "remote"))]` handles the on/off of the `remote` feature without the need for the extra feature. 