### PR TITLE
Use runsc runtime path in `OciManager::run_container`

### DIFF
--- a/crates/compute/src/compute.rs
+++ b/crates/compute/src/compute.rs
@@ -115,8 +115,8 @@ impl OciManager {
         Self { bundler, store }
     }
 
-    pub fn runtime(&self) -> String {
-        self.bundler.runtime.clone()
+    pub fn runtime(&self) -> &String {
+        &self.bundler.runtime
     }
 
     pub fn try_get_store(&self) -> Result<Web3Store, std::io::Error> {
@@ -475,7 +475,7 @@ impl OciManager {
             &container_path,
             &container_id
         );
-        let runsc = self.runtime();
+        let runsc = self.runtime().clone();
         Ok(tokio::spawn(async move {
             // Create temp file for this container to output to
             let temp_file_path = std::env::temp_dir().join(format!("lasr/{}.out", container_id));

--- a/crates/compute/src/compute.rs
+++ b/crates/compute/src/compute.rs
@@ -115,7 +115,7 @@ impl OciManager {
         Self { bundler, store }
     }
 
-    pub fn runtime(&self) -> &String {
+    pub fn runtime(&self) -> &str {
         &self.bundler.runtime
     }
 

--- a/crates/compute/src/compute.rs
+++ b/crates/compute/src/compute.rs
@@ -475,7 +475,7 @@ impl OciManager {
             &container_path,
             &container_id
         );
-        let runsc = self.runtime().clone();
+        let mut runsc = Command::new(self.runtime());
         Ok(tokio::spawn(async move {
             // Create temp file for this container to output to
             let temp_file_path = std::env::temp_dir().join(format!("lasr/{}.out", container_id));
@@ -511,7 +511,7 @@ impl OciManager {
                 )
             })?;
 
-            let mut child = Command::new(runsc)
+            let mut child = runsc
                 .arg("--rootless")
                 .arg("--network=none")
                 .arg("run")

--- a/crates/compute/src/compute.rs
+++ b/crates/compute/src/compute.rs
@@ -115,6 +115,10 @@ impl OciManager {
         Self { bundler, store }
     }
 
+    pub fn runtime(&self) -> String {
+        self.bundler.runtime.clone()
+    }
+
     pub fn try_get_store(&self) -> Result<Web3Store, std::io::Error> {
         let store = if let Some(addr) = &self.store {
             Web3Store::from_multiaddr(addr).map_err(|e| {
@@ -471,6 +475,7 @@ impl OciManager {
             &container_path,
             &container_id
         );
+        let runsc = self.runtime();
         Ok(tokio::spawn(async move {
             // Create temp file for this container to output to
             let temp_file_path = std::env::temp_dir().join(format!("lasr/{}.out", container_id));
@@ -506,7 +511,7 @@ impl OciManager {
                 )
             })?;
 
-            let mut child = Command::new("runsc")
+            let mut child = Command::new(runsc)
                 .arg("--rootless")
                 .arg("--network=none")
                 .arg("run")


### PR DESCRIPTION
Instead of using a string for the command, `"runsc"`, this will use the new environment variable or default path to a runsc binary.