### PR TITLE
Add `flake.nix`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /.lasr
 *.gz
 blocks_processed.dat
+result*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "eo_listener"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "derive_builder 0.12.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3295,9 +3295,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -3327,9 +3327,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",

--- a/README.md
+++ b/README.md
@@ -4,39 +4,19 @@ Language Agnostic Stateless Rollup.
 
 ## Usage
 
-All of our documentation including design details and deploying programs can be found on our documentation site: https://docs.versatus.io/
+There are two main binaries that result from this repository:
+- [lasr_cli](./crates/cli): Command line interface for the `lasr_node` binary.
+- [lasr_node](./crates/node): The LASR node itself.
+
+Further documentation including design details and instructions for deploying programs for LASR can be found on our documentation site: https://docs.versatus.io/
 
 ## Getting Started
 
-The fastest way to see a LASR node in action is by using our internal Nix tooling at https://github.com/versatus/versatus.nix
-which includes a local NixOS VM that will automatically spin up a LASR node and works with Linux/Darwin systems as well as WSL.
-Generic modules are also available there, making it seamless to create a custom image for your personal node server. A production
-configuration is also available for deploying to DigitalOcean servers.
+The fastest way to see a LASR node in action is by using our internal Nix tooling at the root of this project
+which includes a local NixOS VM that will automatically spin up a LASR node and works with Linux/Darwin systems, as well as WSL.
+A GitHub codespaces devcontainer is also available for those who would rather not install Nix as a dependency.
 
-## Environment Variables
-
-### LASR Node Environment Variables
-
-| Environment Variable     | Description                                                      |
-|--------------------------|------------------------------------------------------------------|
-| `SECRET_KEY`             | Used for signing transactions and securing connections.          |
-| `BLOCKS_PROCESSED_PATH`  | Path where processed blocks information is stored.               |
-| `ETH_RPC_URL`            | URL for Ethereum RPC endpoint.                                   |
-| `EO_CONTRACT_ADDRESS`    | Address of the Executable Oracle contract.                       |
-| `COMPUTE_RPC_URL`        | URL for the compute RPC endpoint.                                |
-| `STORAGE_RPC_URL`        | URL for the compute RPC endpoint.                                |
-| `PORT`                   | Optionally specify a port, defaults to `9292`.                   |
-| `BATCH_INTERVAL`         | Interval in secs that transactions are batched, defaults to 180. |
-| `VIPFS_ADDRESS`          | Optional. Used by the OciManager.                                |
-| `RUNSC_BIN_PATH`         | Optionally specify the path to the gVisor runsc binary.          |
-| `GRPCURL_BIN_PATH`       | Optionally specify the path to the grpcurl binary.               |
-| `EIGENDA_SERVER_ADDRESS` | Optional. Defaults to `disperser-holesky.eigenda.xyz:443`.       |
-
-### LASR CLI Environment Variables
-
-| Environment Variable   | Description                                                               |
-|------------------------|---------------------------------------------------------------------------|
-| `LASR_RPC_URL`         | URL used for remote procedure calls, defaults to `http://127.0.0.1:9292`. |
+A guide for installing Nix can be found here: https://github.com/versatus/versatus.nix.
 
 ## Contributing Guide
 
@@ -45,21 +25,29 @@ answer any questions.
 
 ### Fork And Clone The Repository
 Create your own fork of the `lasr` repository, and create a local copy of your fork.
-```
+```sh
 git clone github:<your-username>/lasr
 ```
 
 ### Build The Project
 LASR is built with Rust, so a Rust toolchain is a pre-requisite. If you have `rustup` installed
 the project's `rust-toolchain.toml` will enable the current toolchain our core team uses.
-```
+
+```sh
 cd lasr && cargo build
+```
+
+Nix users can start an interactive development shell with `nix develop`, which provides the Rust toolchain automatically.
+
+```sh
+cd lasr && nix develop
+cargo build
 ```
 
 ### Testing Your Changes
 To see your changes take effect, we suggest adding an appropriate unit or integration test, however
-some testing cases (such as bug fixes) may require manual testing, in which case using the [`versatus.nix` flake](https://github.com/versatus/versatus.nix)
-is the easiest option. After following the setup steps there, testing your changes is straight-forward:
+some testing cases (such as bug fixes) may require manual testing, in which case using the project's nix flake
+is the easiest option. See [Getting Started](#getting-started) for setup steps, then testing your changes is straight-forward:
 
 - unit or integration tests with `cargo`
 ```sh
@@ -67,13 +55,9 @@ is the easiest option. After following the setup steps there, testing your chang
 cargo test --workspace --features mock_storage
 ```
 
-- `versatus.nix` manual debugging
-
-> Note: To see your changes take effect, you will need to replace `inputs.lasr.url` in the `flake.nix`
-> with the URL to your upstream branch.
+- NixOS VM manual debugging
 
 ```sh
-nix flake update # updates flake inputs, see note above
 nix build .#lasr_vm
 ./result/bin/run-lasr-debug-server-vm
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cargo test --workspace --features mock_storage
 ```sh
 nix flake update # updates flake inputs, see note above
 nix build .#lasr_vm
-./result/bin/run-lasr-nightly-server-vm
+./result/bin/run-lasr-debug-server-vm
 ```
 
 > Note: A qemu terminal should appear which you can either login as root, or ssh into.

--- a/crates/actors/Cargo.toml
+++ b/crates/actors/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lasr_actors"
+publish = false
 version = "0.9.0"
 edition = "2021"
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lasr_cli"
+publish = false
 version = "0.9.0"
 edition = "2021"
 

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -1,0 +1,22 @@
+# lasr_cli
+
+Command line interface for interacting with a LASR node.
+
+## Prerequisites
+
+### System
+
+Unlike its node counterpart, the node CLI is meant to work on any system. A work-in-progress statically linked
+binary is available through the Nix flake at the root of the project, and development is on-going.
+Non-statically linked binaries are already available for the following systems:
+
+- x86_64-linux
+- x86_64-darwin
+- aarch64-linux
+- aarch64-darwin
+
+### Environment Variables
+
+| Environment Variable   | Description                                                               |
+|------------------------|---------------------------------------------------------------------------|
+| `LASR_RPC_URL`         | URL used for remote procedure calls, defaults to `http://127.0.0.1:9292`. |

--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lasr_compute"
+publish = false
 version = "0.9.0"
 edition = "2021"
 

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lasr_contract"
+publish = false
 version = "0.9.0"
 edition = "2021"
 

--- a/crates/eo_listener/Cargo.toml
+++ b/crates/eo_listener/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "eo_listener"
-version = "0.1.0"
+publish = false
+version = "0.9.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/messages/Cargo.toml
+++ b/crates/messages/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lasr_messages"
+publish = false
 version = "0.9.0"
 edition = "2021"
 

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lasr_node"
+publish = false
 version = "0.9.0"
 edition = "2021"
 

--- a/crates/node/README.md
+++ b/crates/node/README.md
@@ -1,0 +1,49 @@
+# lasr_node
+
+The LASR node binary.
+
+## Prerequisites
+
+### System
+
+The `lasr_node` binary relies heavily on some Linux-only dependencies, listed under [System Dependencies](#system-dependencies) below.
+Therefore, it requires Linux, meaning either your system must have Linux installed or be capable of running a Linux container.
+This is confirmed working with Nix for the following targets, but may also be possible on others such as WSL:
+
+- x86_64-linux
+- x86_64-darwin
+- aarch64-linux
+- aarch64-darwin
+
+> Note: MacOS must use the `nix-darwin` linux builder feature in order to work.
+> See https://github.com/versatus/versatus.nix/blob/master/README.md for details.
+
+### System Dependencies
+
+Listed are dependencies that must be present on your system for the LASR node to run.
+
+- gVisor (`runsc`): At the time of writing, only available for AMD64 and ARM64 Linux.
+- IPFS
+- grpcurl
+
+### Environment Variables
+
+An [example configuration](./.env-sample) can be found at the root of _this crate_.
+
+On some systems, the default path and command for `runsc` and `grpcurl` may fail. In such cases,
+setting their respective binary path variables may help.
+
+| Environment Variable     | Description                                                      |
+|--------------------------|------------------------------------------------------------------|
+| `SECRET_KEY`             | Used for signing transactions and securing connections.          |
+| `BLOCKS_PROCESSED_PATH`  | Path where processed blocks information is stored.               |
+| `ETH_RPC_URL`            | URL for Ethereum RPC endpoint.                                   |
+| `EO_CONTRACT_ADDRESS`    | Address of the Executable Oracle contract.                       |
+| `COMPUTE_RPC_URL`        | URL for the compute RPC endpoint.                                |
+| `STORAGE_RPC_URL`        | URL for the compute RPC endpoint.                                |
+| `PORT`                   | Optionally specify a port, defaults to `9292`.                   |
+| `BATCH_INTERVAL`         | Interval in secs that transactions are batched, defaults to 180. |
+| `VIPFS_ADDRESS`          | Optional. Used by the OciManager.                                |
+| `RUNSC_BIN_PATH`         | Optionally specify the path to the gVisor runsc binary.          |
+| `GRPCURL_BIN_PATH`       | Optionally specify the path to the grpcurl binary.               |
+| `EIGENDA_SERVER_ADDRESS` | Optional. Defaults to `disperser-holesky.eigenda.xyz:443`.       |

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lasr_rpc"
+publish = false
 version = "0.9.0"
 edition = "2021"
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lasr_types"
-publish = false # Consider publishing for SDKs
+publish = false     # Consider publishing for SDKs
 version = "0.9.0"
 edition = "2021"
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lasr_types"
+publish = false # Consider publishing for SDKs
 version = "0.9.0"
 edition = "2021"
 

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "lasr_wallet"
+publish = false
 version = "0.9.0"
 edition = "2021"
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,35 @@
+[bans]
+multiple-versions = 'allow' # allow multiple versions of the same license
+
+[licenses]
+private = { ignore = true } # ignore workspace crates that won't be published
+allow = [
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "MIT",
+  "Unicode-DFS-2016",
+  "CC0-1.0",
+  "ISC",
+  "OpenSSL",
+]
+
+# Copied from https://github.com/EmbarkStudios/cargo-deny/blob/6344cc566621410a0865632b4ef0e82a20408676/deny.toml#L63
+[[licenses.clarify]]
+crate = "ring"
+# SPDX considers OpenSSL to encompass both the OpenSSL and SSLeay licenses
+# https://spdx.org/licenses/OpenSSL.html
+# ISC - Both BoringSSL and ring use this for their new files
+# MIT - "Files in third_party/ have their own licenses, as described therein. The MIT
+# license, for third_party/fiat, which, unlike other third_party directories, is
+# compiled into non-test libraries, is included below."
+# OpenSSL - Obviously
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[advisories]
+version = 2
+ignore = [
+  { id = "RUSTSEC-2021-0141", reason = "may be valid, more research is necessary." },
+  { id = "RUSTSEC-2021-0145", reason = "may be valid, more research is necessary." },
+]

--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1721370560,
-        "narHash": "sha256-3GHNXsPZQRY4yPyov9vD6DAapdb4ZXJp8qpQY2u0lWQ=",
+        "lastModified": 1721456965,
+        "narHash": "sha256-AJjRiL2diAitpARbE9bUTlgtqHC8QS1ImXNaXMRhKoU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "13b935cb8e697913298acca8309cf031336497f7",
+        "rev": "d3121c162a1fa4fabcb9af9642d50e8b05ddfe83",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721403608,
-        "narHash": "sha256-X5+QA5K3J2KA20YEaBJ+GKDj/XIb5PutHmphgYQUszA=",
+        "lastModified": 1721466660,
+        "narHash": "sha256-pFSxgSZqZ3h+5Du0KvEL1ccDZBwu4zvOil1zzrPNb3c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad0111043c09f7d0f6b9f039882cbf350d4f7d49",
+        "rev": "6e14bbce7bea6c4efd7adfa88a40dac750d80100",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         "versatus": "versatus"
       },
       "locked": {
-        "lastModified": 1721446288,
-        "narHash": "sha256-zcazy3N5m/YUoH1wIFyYqa8EclfAnYWeLLZk8WvDeXA=",
+        "lastModified": 1721516816,
+        "narHash": "sha256-t654VcPHl4nomp0gICEqU+F4/JdM1uY1tRhccO/hwy4=",
         "owner": "versatus",
         "repo": "versatus.nix",
-        "rev": "99546182b90b0d3b685946f8150cdabed085c9eb",
+        "rev": "18a1a24c78487189c9ce4b88fe76e0eff596094f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "advisory-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1721383898,
-        "narHash": "sha256-oB7n3qZp0cVRiiFTSisg2eYfIbFXsbGWK/ZBD02Auq8=",
+        "lastModified": 1721582928,
+        "narHash": "sha256-nlnB4V0pFo+hAZpyAixAOYWxhVNFyDHGazXnz7PhrEk=",
         "owner": "rustsec",
         "repo": "advisory-db",
-        "rev": "eb081cbca8853b7481aec2f194627fa639bc5e62",
+        "rev": "c0b44f487d8d67d1c6cd369917eb684eff918b64",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         "rust-analyzer-src": []
       },
       "locked": {
-        "lastModified": 1721456965,
-        "narHash": "sha256-AJjRiL2diAitpARbE9bUTlgtqHC8QS1ImXNaXMRhKoU=",
+        "lastModified": 1721543262,
+        "narHash": "sha256-6m2G2pGmFjPGeXDs0FqhDfdACCCcFN3XMWHEyTTyTXo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d3121c162a1fa4fabcb9af9642d50e8b05ddfe83",
+        "rev": "a01667fc71674454dd9ec2669afc0b326a275796",
         "type": "github"
       },
       "original": {
@@ -114,11 +114,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1721466660,
-        "narHash": "sha256-pFSxgSZqZ3h+5Du0KvEL1ccDZBwu4zvOil1zzrPNb3c=",
+        "lastModified": 1721559948,
+        "narHash": "sha256-cFgdjyK/VBM3hB1RfFHXcI/VOCBVAv813s1upHKX7bI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e14bbce7bea6c4efd7adfa88a40dac750d80100",
+        "rev": "c19d62ad2265b16e2199c5feb4650fe459ca1c46",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
         "versatus": "versatus"
       },
       "locked": {
-        "lastModified": 1721516816,
-        "narHash": "sha256-t654VcPHl4nomp0gICEqU+F4/JdM1uY1tRhccO/hwy4=",
+        "lastModified": 1721604062,
+        "narHash": "sha256-RoXYpqqqypUM6UgjU/E8IgnXkL4x2/28AL2N+yiXPDw=",
         "owner": "versatus",
         "repo": "versatus.nix",
-        "rev": "18a1a24c78487189c9ce4b88fe76e0eff596094f",
+        "rev": "300aa128f1cfa19c493966e481dd839891fade33",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,204 @@
+{
+  "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1721383898,
+        "narHash": "sha256-oB7n3qZp0cVRiiFTSisg2eYfIbFXsbGWK/ZBD02Auq8=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "eb081cbca8853b7481aec2f194627fa639bc5e62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721322122,
+        "narHash": "sha256-a0G1NvyXGzdwgu6e1HQpmK5R5yLsfxeBe07nNDyYd+g=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8a68b987c476a33e90f203f0927614a75c3f47ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "crane_2": {
+      "inputs": {
+        "nixpkgs": [
+          "versatus-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721322122,
+        "narHash": "sha256-a0G1NvyXGzdwgu6e1HQpmK5R5yLsfxeBe07nNDyYd+g=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8a68b987c476a33e90f203f0927614a75c3f47ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": []
+      },
+      "locked": {
+        "lastModified": 1721370560,
+        "narHash": "sha256-3GHNXsPZQRY4yPyov9vD6DAapdb4ZXJp8qpQY2u0lWQ=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "13b935cb8e697913298acca8309cf031336497f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "lasr": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1721333030,
+        "narHash": "sha256-9ZOIw3JE8wPWo5+apNe0ks/iMBxTFYZ8bWBimsm8NTc=",
+        "owner": "versatus",
+        "repo": "lasr",
+        "rev": "8be70184898dc0278fcd098992dd6aee6fb71c2d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "versatus",
+        "repo": "lasr",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1721403608,
+        "narHash": "sha256-X5+QA5K3J2KA20YEaBJ+GKDj/XIb5PutHmphgYQUszA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ad0111043c09f7d0f6b9f039882cbf350d4f7d49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "advisory-db": "advisory-db",
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "versatus-nix": "versatus-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "versatus": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717000637,
+        "narHash": "sha256-oCKOYZPSGT+Hbp/IoyzeEzPwBkogkYIJA+Eu8IXhGMY=",
+        "owner": "versatus",
+        "repo": "versatus",
+        "rev": "217a0e73fa9284286e1482d50c2af260ada4f51c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "versatus",
+        "repo": "versatus",
+        "type": "github"
+      }
+    },
+    "versatus-nix": {
+      "inputs": {
+        "crane": "crane_2",
+        "fenix": [
+          "fenix"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "lasr": "lasr",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "versatus": "versatus"
+      },
+      "locked": {
+        "lastModified": 1721446288,
+        "narHash": "sha256-zcazy3N5m/YUoH1wIFyYqa8EclfAnYWeLLZk8WvDeXA=",
+        "owner": "versatus",
+        "repo": "versatus.nix",
+        "rev": "99546182b90b0d3b685946f8150cdabed085c9eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "versatus",
+        "repo": "versatus.nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -31,309 +31,312 @@
   };
 
   outputs = { self, nixpkgs, crane, fenix, flake-utils, advisory-db, versatus-nix, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        inherit (pkgs) lib;
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          inherit (pkgs) lib;
 
-        versaLib = versatus-nix.lib.${system};
-        rustToolchain = versaLib.toolchains.mkRustToolchainFromTOML
-          ./rust-toolchain.toml
-          "sha256-SXRtAuO4IqNOQq+nLbrsDFbVk+3aVA8NNpSZsKlVH/8=";
+          versaLib = versatus-nix.lib.${system};
+          rustToolchain = versaLib.toolchains.mkRustToolchainFromTOML
+            ./rust-toolchain.toml
+            "sha256-SXRtAuO4IqNOQq+nLbrsDFbVk+3aVA8NNpSZsKlVH/8=";
 
-        # Overrides the default crane rust-toolchain with fenix.
-        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain.fenix-pkgs;
-        workspace = rec {
-          # Inherit the workspace version from the node crate since the workspace is not a package.
-          inherit (craneLib.crateNameFromCargoToml { cargoToml = (root + "/crates/node/Cargo.toml"); }) version;
-          name = "lasr";
-          root = ./.;
-          src = craneLib.cleanCargoSource root;
-        };
-
-        # Common arguments can be set here to avoid repeating them later
-        commonArgs = {
-          inherit (workspace) version src;
-          pname = workspace.name;
-          strictDeps = true;
-
-          # Inputs that must be available at the time of the build
-          nativeBuildInputs = [ pkgs.pkg-config ];
-
-          buildInputs = [
-            pkgs.openssl.dev
-            rustToolchain.darwin-pkgs
-          ];
-        };
-
-        # Build *just* the cargo dependencies, so we can reuse
-        # all of that work (e.g. via cachix) when running in CI
-        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
-        individualCrateArgs = commonArgs // {
-          inherit cargoArtifacts;
-          doCheck = false; # Use cargo-nextest below.
-        };
-
-        fileSetForCrate = crate: lib.fileset.toSource {
-          root = workspace.root;
-          fileset = lib.fileset.unions [
-            ./Cargo.toml
-            ./Cargo.lock
-            ./crates
-            (workspace.root + crate)
-          ];
-        };
-
-        # Build the top-level crates of the workspace as individual derivations.
-        # This allows consumers to only depend on (and build) only what they need.
-        # Though it is possible to build the entire workspace as a single derivation,
-        # in this case the workspace itself is not a package.
-        mkCrateDrv = crate:
-          let
-            manifest = craneLib.crateNameFromCargoToml {
-              cargoToml = (workspace.root + "${crate}/Cargo.toml");
-            };
-          in
-          craneLib.buildPackage (individualCrateArgs // {
-            inherit (manifest) version pname;
-            cargoExtraArgs = "--locked --bin ${manifest.pname}";
-            src = fileSetForCrate crate;
-          });
-
-        lasr_cli = mkCrateDrv "/crates/cli";
-        lasr_node = mkCrateDrv "/crates/node";
-      in
-      {
-        checks = {
-          # Build the crate as part of `nix flake check` for convenience
-          inherit lasr_cli lasr_node;
-
-          # Run clippy (and deny all warnings) on the workspace source,
-          # again, reusing the dependency artifacts from above.
-          #
-          # Note that this is done as a separate derivation so that
-          # we can block the CI if there are issues here, but not
-          # prevent downstream consumers from building our crate by itself.
-          workspace-clippy = craneLib.cargoClippy (commonArgs // {
-            inherit cargoArtifacts;
-            pname = workspace.name;
-            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
-          });
-
-          workspace-doc = craneLib.cargoDoc (commonArgs // {
-            inherit cargoArtifacts;
-            pname = workspace.name;
-          });
-
-          # Check formatting
-          workspace-fmt = craneLib.cargoFmt {
-            inherit (workspace) version src;
-            pname = workspace.name;
+          # Overrides the default crane rust-toolchain with fenix.
+          craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain.fenix-pkgs;
+          workspace = rec {
+            # Inherit the workspace version from the node crate since the workspace is not a package.
+            inherit (craneLib.crateNameFromCargoToml { cargoToml = (root + "/crates/node/Cargo.toml"); }) version;
+            name = "lasr";
+            root = ./.;
+            src = craneLib.cleanCargoSource root;
           };
 
-          # Audit dependencies
-          workspace-audit = craneLib.cargoAudit {
-            inherit (workspace) version src;
-            inherit advisory-db;
-            pname = workspace.name;
-          };
-
-          # Audit licenses
-          workspace-deny = craneLib.cargoDeny {
+          # Common arguments can be set here to avoid repeating them later
+          commonArgs = {
             inherit (workspace) version src;
             pname = workspace.name;
-          };
+            strictDeps = true;
 
-          # Run tests with cargo-nextest
-          # Consider setting `doCheck = false` on other crate derivations
-          # if you do not want the tests to run twice
-          workspace-nextest = craneLib.cargoNextest (commonArgs // {
-            inherit cargoArtifacts;
-            pname = workspace.name;
-            partitions = 1;
-            partitionType = "count";
-          });
-        };
+            # Inputs that must be available at the time of the build
+            nativeBuildInputs = [ pkgs.pkg-config ];
 
-        packages =
-          let
-            hostPkgs = pkgs;
-            guest_system = versaLib.virtualisation.mkGuestSystem pkgs;
-            # Build packages for the linux variant of the host architecture, but preserve the host's
-            # version of nixpkgs to build the virtual machine with. This way, building and running a
-            # linux virtual environment works for all supported system architectures.
-            lasrGuestVM = nixpkgs.lib.nixosSystem {
-              system = null;
-              modules = [
-                ./nixos/modules/deployments/common
-                ./nixos/modlues/deployments/debug/debug-options.nix
-                versatus-nix.nixosModules.deployments.debugVm
-                ({
-                  # MacOS specific stuff
-                  virtualisation.host.pkgs = hostPkgs;
-                  nixpkgs.hostPlatform = guest_system;
-                })
-                ({
-                  nixpkgs.overlays = [
-                    self.overlays.lasr-overlay
-                    self.overlays.rust-overlay
-                  ];
-                })
-              ];
-            };
-            # This would under normal circumstances be made available through `self.nixosConfigurations`
-            # however, we want the darwin systems to build linux images since the `lasr_node` binary
-            # has linux-only dependencies. Using the `nix-darwin` linux builder, MacOS users can still
-            # build this image for deployment, and can use the `lasr-vm` for debugging.
-            mkDigitalOceanImage = extraModules:
-              nixpkgs.lib.nixosSystem {
-                system = guest_system;
-                modules = [
-                  ./nixos/modules/deployments/common
-                  versatus-nix.nixosModules.deployments.digitalOcean.digitalOceanImage
-                  ({
-                    nixpkgs.overlays = [
-                      self.overlays.lasr-overlay
-                      self.overlays.rust-overlay
-                    ];
-                  })
-                ] ++ extraModules;
-              };
-            debugDigitalOceanImage = mkDigitalOceanImage [
-              ./nixos/modules/deployments/debug/debug-options.nix
+            buildInputs = [
+              pkgs.openssl.dev
+              rustToolchain.darwin-pkgs
             ];
-          in
-          {
+          };
+
+          # Build *just* the cargo dependencies, so we can reuse
+          # all of that work (e.g. via cachix) when running in CI
+          cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+          individualCrateArgs = commonArgs // {
+            inherit cargoArtifacts;
+            doCheck = false; # Use cargo-nextest below.
+          };
+
+          fileSetForCrate = crate: lib.fileset.toSource {
+            root = workspace.root;
+            fileset = lib.fileset.unions [
+              ./Cargo.toml
+              ./Cargo.lock
+              ./crates
+              (workspace.root + crate)
+            ];
+          };
+
+          # Build the top-level crates of the workspace as individual derivations.
+          # This allows consumers to only depend on (and build) only what they need.
+          # Though it is possible to build the entire workspace as a single derivation,
+          # in this case the workspace itself is not a package.
+          mkCrateDrv = crate:
+            let
+              manifest = craneLib.crateNameFromCargoToml {
+                cargoToml = (workspace.root + "${crate}/Cargo.toml");
+              };
+            in
+            craneLib.buildPackage (individualCrateArgs // {
+              inherit (manifest) version pname;
+              cargoExtraArgs = "--locked --bin ${manifest.pname}";
+              src = fileSetForCrate crate;
+            });
+
+          lasr_cli = mkCrateDrv "/crates/cli";
+          lasr_node = mkCrateDrv "/crates/node";
+        in
+        {
+          checks = {
+            # Build the crate as part of `nix flake check` for convenience
             inherit lasr_cli lasr_node;
 
-            lasr_debug_image =
-              debugDigitalOceanImage.config.system.build.digitalOceanImage;
-
-            # Spin up a virtual machine with the lasr_debug_image options
-            # Useful for quickly debugging or testing changes locally
-            lasr_vm = lasrGuestVM.config.system.build.vm;
-
-            # TODO: Fix musl static linking
-            # lasr_cli_cross = # this works on Linux only at the moment
-            #   let
-            #     archPrefix = builtins.elemAt (pkgs.lib.strings.split "-" system) 0;
-            #     target = "${archPrefix}-unknown-linux-musl";
-
-            #     staticCraneLib =
-            #       let rustMuslToolchain = with fenix.packages.${system}; combine [
-            #           minimal.cargo
-            #           minimal.rustc
-            #           targets.${target}.latest.rust-std
-            #         ];
-            #       in
-            #       (crane.mkLib pkgs).overrideToolchain rustMuslToolchain;
-
-            #     buildLasrCliStatic = { stdenv, pkg-config, openssl, libiconv, darwin }:
-            #       staticCraneLib.buildPackage {
-            #         pname = "lasr_cli";
-            #         version = "1";
-            #         src = lasrSrc;
-            #         strictDeps = true;
-            #         nativeBuildInputs = [ pkg-config ];
-            #         buildInputs = [
-            #           (openssl.override { static = true; })
-            #           rustToolchain.darwin-pkgs
-            #         ];
-
-            #         doCheck = false;
-            #         cargoExtraArgs = "--locked --bin lasr_cli";
-
-            #         CARGO_BUILD_TARGET = target;
-            #         CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-            #       };
-            #   in
-            #   pkgs.pkgsMusl.callPackage buildLasrCliStatic {}; # TODO: needs fix, pkgsMusl not available on darwin systems
-
-            # TODO: Getting CC linker error
-            # lasr_cli_windows =
-            #   let
-            #     crossPkgs = import nixpkgs {
-            #       crossSystem = pkgs.lib.systems.examples.mingwW64;
-            #       localSystem = system;
-            #     };
-            #     craneLib = 
-            #       let 
-            #         rustToolchain = with fenix.packages.${system}; combine [
-            #             minimal.cargo
-            #             minimal.rustc
-            #             targets.x86_64-pc-windows-gnu.latest.rust-std
-            #           ];
-            #       in
-            #       (crane.mkLib crossPkgs).overrideToolchain rustToolchain;
-
-            #     inherit (crossPkgs.stdenv.targetPlatform.rust)
-            #       cargoEnvVarTarget cargoShortTarget;
-
-            #     buildLasrCli = { stdenv, pkg-config, openssl, libiconv, windows }:
-            #       craneLib.buildPackage {
-            #         pname = "lasr_node";
-            #         version = "1";
-            #         src = lasrSrc;
-            #         strictDeps = true;
-            #         nativeBuildInputs = [ pkg-config ];
-            #         buildInputs = [
-            #           (openssl.override { static = true; })
-            #           windows.pthreads
-            #         ];
-
-            #         doCheck = false;
-            #         cargoExtraArgs = "--locked --bin lasr_cli";
-
-            #         CARGO_BUILD_TARGET = cargoShortTarget;
-            #         CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
-            #         "CARGO_TARGET_${cargoEnvVarTarget}_LINKER" = "${stdenv.cc.targetPrefix}cc";
-            #         HOST_CC = "${stdenv.cc.nativePrefix}cc";
-            #       };
-            #   in
-            #   crossPkgs.callPackage buildLasrCli {};
-          } // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
-            workspace-llvm-coverage = craneLib.cargoLlvmCov (commonArgs // {
+            # Run clippy (and deny all warnings) on the workspace source,
+            # again, reusing the dependency artifacts from above.
+            #
+            # Note that this is done as a separate derivation so that
+            # we can block the CI if there are issues here, but not
+            # prevent downstream consumers from building our crate by itself.
+            workspace-clippy = craneLib.cargoClippy (commonArgs // {
               inherit cargoArtifacts;
+              pname = workspace.name;
+              cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+            });
+
+            workspace-doc = craneLib.cargoDoc (commonArgs // {
+              inherit cargoArtifacts;
+              pname = workspace.name;
+            });
+
+            # Check formatting
+            workspace-fmt = craneLib.cargoFmt {
+              inherit (workspace) version src;
+              pname = workspace.name;
+            };
+
+            # Audit dependencies
+            workspace-audit = craneLib.cargoAudit {
+              inherit (workspace) version src;
+              inherit advisory-db;
+              pname = workspace.name;
+            };
+
+            # Audit licenses
+            workspace-deny = craneLib.cargoDeny {
+              inherit (workspace) version src;
+              pname = workspace.name;
+            };
+
+            # Run tests with cargo-nextest
+            # Consider setting `doCheck = false` on other crate derivations
+            # if you do not want the tests to run twice
+            workspace-nextest = craneLib.cargoNextest (commonArgs // {
+              inherit cargoArtifacts;
+              pname = workspace.name;
+              partitions = 1;
+              partitionType = "count";
             });
           };
 
-        apps = {
-          lasr_cli = flake-utils.lib.mkApp {
-            drv = lasr_cli;
-          };
-          lasr_node = flake-utils.lib.mkApp {
-            drv = lasr_node;
-          };
-        };
+          packages =
+            let
+              hostPkgs = pkgs;
+              guest_system = versaLib.virtualisation.mkGuestSystem pkgs;
+              # Build packages for the linux variant of the host architecture, but preserve the host's
+              # version of nixpkgs to build the virtual machine with. This way, building and running a
+              # linux virtual environment works for all supported system architectures.
+              lasrGuestVM = nixpkgs.lib.nixosSystem {
+                system = null;
+                modules = [
+                  ./nixos/modules/deployments/common
+                  ./nixos/modules/deployments/debug/debug-options.nix
+                  versatus-nix.nixosModules.deployments.debugVm
+                  ({
+                    # Use the version of nixpkgs from the host to build the virtual image.
+                    virtualisation.host.pkgs = hostPkgs;
+                    nixpkgs.hostPlatform = guest_system;
+                  })
+                  ({
+                    nixpkgs.overlays = [
+                      self.overlays.rust-overlay
+                      self.overlays.lasr-overlay
+                    ];
+                  })
+                ];
+              };
+              # This would under normal circumstances be made available through `self.nixosConfigurations`
+              # however, we want the darwin systems to build linux images since the `lasr_node` binary
+              # has linux-only dependencies. Using the `nix-darwin` linux builder, MacOS users can still
+              # build this image for deployment, and can use the `lasr-vm` for debugging.
+              mkDigitalOceanImage = extraModules:
+                nixpkgs.lib.nixosSystem {
+                  system = guest_system;
+                  modules = [
+                    ./nixos/modules/deployments/common
+                    versatus-nix.nixosModules.deployments.digitalOcean.digitalOceanImage
+                    ({
+                      nixpkgs.overlays = [
+                        self.overlays.rust-overlay
+                        self.overlays.lasr-overlay
+                      ];
+                    })
+                  ] ++ extraModules;
+                };
+              debugDigitalOceanImage = mkDigitalOceanImage [
+                ./nixos/modules/deployments/debug/debug-options.nix
+              ];
+            in
+            {
+              inherit lasr_cli lasr_node;
 
-        devShells.default = craneLib.devShell {
-          # Inherit inputs from checks.
-          checks = self.checks.${system};
+              lasr_debug_image =
+                debugDigitalOceanImage.config.system.build.digitalOceanImage;
 
-          # Extra inputs can be added here; cargo and rustc are provided by default.
-          #
-          # In addition, these packages and the `rustToolchain` are inherited from checks above:
-          # cargo-audit
-          # cargo-deny
-          # cargo-nextest
-          packages = with pkgs; [
-            # ripgrep
-            nil # nix lsp
-            nixpkgs-fmt # nix formatter
-          ];
-        };
+              # Spin up a virtual machine with the lasr_debug_image options
+              # Useful for quickly debugging or testing changes locally
+              lasr_vm = lasrGuestVM.config.system.build.vm;
 
-        formatter = pkgs.nixpkgs-fmt;
-      }) // {
-        overlays = {
-          lasr-overlay = import ./nixos/overlay.nix;
-          rust-overlay = final: prev: {
-            # This contains a lot of policy decisions which rust toolchain is used
-            craneLib = (self.inputs.crane.mkLib prev).overrideToolchain final.rustToolchain.fenix-pkgs;
-            rustToolchain = prev.versaLib.toolchains.mkRustToolchainFromTOML
-              ./rust-toolchain.toml
-              "sha256-SXRtAuO4IqNOQq+nLbrsDFbVk+3aVA8NNpSZsKlVH/8=";
+              # TODO: Fix musl static linking
+              # lasr_cli_cross = # this works on Linux only at the moment
+              #   let
+              #     archPrefix = builtins.elemAt (pkgs.lib.strings.split "-" system) 0;
+              #     target = "${archPrefix}-unknown-linux-musl";
+
+              #     staticCraneLib =
+              #       let rustMuslToolchain = with fenix.packages.${system}; combine [
+              #           minimal.cargo
+              #           minimal.rustc
+              #           targets.${target}.latest.rust-std
+              #         ];
+              #       in
+              #       (crane.mkLib pkgs).overrideToolchain rustMuslToolchain;
+
+              #     buildLasrCliStatic = { stdenv, pkg-config, openssl, libiconv, darwin }:
+              #       staticCraneLib.buildPackage {
+              #         pname = "lasr_cli";
+              #         version = "1";
+              #         src = lasrSrc;
+              #         strictDeps = true;
+              #         nativeBuildInputs = [ pkg-config ];
+              #         buildInputs = [
+              #           (openssl.override { static = true; })
+              #           rustToolchain.darwin-pkgs
+              #         ];
+
+              #         doCheck = false;
+              #         cargoExtraArgs = "--locked --bin lasr_cli";
+
+              #         CARGO_BUILD_TARGET = target;
+              #         CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+              #       };
+              #   in
+              #   pkgs.pkgsMusl.callPackage buildLasrCliStatic {}; # TODO: needs fix, pkgsMusl not available on darwin systems
+
+              # TODO: Getting CC linker error
+              # lasr_cli_windows =
+              #   let
+              #     crossPkgs = import nixpkgs {
+              #       crossSystem = pkgs.lib.systems.examples.mingwW64;
+              #       localSystem = system;
+              #     };
+              #     craneLib = 
+              #       let 
+              #         rustToolchain = with fenix.packages.${system}; combine [
+              #             minimal.cargo
+              #             minimal.rustc
+              #             targets.x86_64-pc-windows-gnu.latest.rust-std
+              #           ];
+              #       in
+              #       (crane.mkLib crossPkgs).overrideToolchain rustToolchain;
+
+              #     inherit (crossPkgs.stdenv.targetPlatform.rust)
+              #       cargoEnvVarTarget cargoShortTarget;
+
+              #     buildLasrCli = { stdenv, pkg-config, openssl, libiconv, windows }:
+              #       craneLib.buildPackage {
+              #         pname = "lasr_node";
+              #         version = "1";
+              #         src = lasrSrc;
+              #         strictDeps = true;
+              #         nativeBuildInputs = [ pkg-config ];
+              #         buildInputs = [
+              #           (openssl.override { static = true; })
+              #           windows.pthreads
+              #         ];
+
+              #         doCheck = false;
+              #         cargoExtraArgs = "--locked --bin lasr_cli";
+
+              #         CARGO_BUILD_TARGET = cargoShortTarget;
+              #         CARGO_BUILD_RUSTFLAGS = "-C target-feature=+crt-static";
+              #         "CARGO_TARGET_${cargoEnvVarTarget}_LINKER" = "${stdenv.cc.targetPrefix}cc";
+              #         HOST_CC = "${stdenv.cc.nativePrefix}cc";
+              #       };
+              #   in
+              #   crossPkgs.callPackage buildLasrCli {};
+            } // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+              workspace-llvm-coverage = craneLib.cargoLlvmCov (commonArgs // {
+                inherit cargoArtifacts;
+              });
+            };
+
+          apps = {
+            lasr_cli = flake-utils.lib.mkApp {
+              drv = lasr_cli;
+            };
+            lasr_node = flake-utils.lib.mkApp {
+              drv = lasr_node;
+            };
           };
+
+          devShells.default = craneLib.devShell {
+            # Inherit inputs from checks.
+            checks = self.checks.${system};
+
+            # Extra inputs can be added here; cargo and rustc are provided by default.
+            #
+            # In addition, these packages and the `rustToolchain` are inherited from checks above:
+            # cargo-audit
+            # cargo-deny
+            # cargo-nextest
+            packages = with pkgs; [
+              # ripgrep
+              nil # nix lsp
+              nixpkgs-fmt # nix formatter
+            ];
+          };
+
+          formatter = pkgs.nixpkgs-fmt;
+        }) // {
+      overlays = {
+        # Build lasr_cli & lasr_node so we can add their derivations to a configuration
+        lasr-overlay = import ./nixos/overlay.nix;
+
+        # This contains a lot of policy decisions which rust toolchain is used
+        rust-overlay = final: prev: {
+          craneLib = (self.inputs.crane.mkLib prev).overrideToolchain final.rustToolchain.fenix-pkgs;
+          rustToolchain = self.inputs.versatus-nix.lib.${prev.system}.toolchains.mkRustToolchainFromTOML
+            ./rust-toolchain.toml
+            "sha256-SXRtAuO4IqNOQq+nLbrsDFbVk+3aVA8NNpSZsKlVH/8=";
         };
       };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,181 @@
+{
+  description = "Versatus rust-based project template.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.rust-analyzer-src.follows = "";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
+
+    versatus-nix = {
+      url = "github:versatus/versatus.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.fenix.follows = "fenix";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+  };
+
+  outputs = { self, nixpkgs, crane, fenix, flake-utils, advisory-db, versatus-nix, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        inherit (pkgs) lib;
+
+        toolchains = versatus-nix.toolchains.${system};
+
+        rustToolchain = toolchains.mkRustToolchainFromTOML
+          ./rust-toolchain.toml
+          "sha256-SXRtAuO4IqNOQq+nLbrsDFbVk+3aVA8NNpSZsKlVH/8=";
+
+        # Overrides the default crane rust-toolchain with fenix.
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain.fenix-pkgs;
+        src = craneLib.cleanCargoSource ./.;
+
+        # Common arguments can be set here to avoid repeating them later
+        commonArgs = {
+          inherit src;
+          version = "0.9.0";
+          strictDeps = true;
+
+          # Inputs that must be available at the time of the build
+          nativeBuildInputs = [
+            pkgs.pkg-config # necessary for linking OpenSSL
+          ];
+
+          buildInputs = [
+            pkgs.openssl.dev
+            rustToolchain.darwin-pkgs
+          ];
+        };
+
+        # Build *just* the cargo dependencies, so we can reuse
+        # all of that work (e.g. via cachix) when running in CI
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+        individualCrateArgs = commonArgs // {
+          inherit cargoArtifacts;
+          inherit (craneLib.crateNameFromCargoToml { inherit src; }) version;
+          doCheck = false; # Use cargo-nextest below.
+        };
+
+        fileSetForCrate = crate: lib.fileset.toSource {
+          root = ./.;
+          fileset = lib.fileset.unions [
+            ./Cargo.toml
+            ./Cargo.lock
+            ./crates
+            crate
+          ];
+        };
+
+        # Build the top-level crates of the workspace as individual derivations.
+        # This allows consumers to only depend on (and build) only what they need.
+        # Though it is possible to build the entire workspace as a single derivation,
+        # so this is left up to you on how to organize things
+        lasr_cli = craneLib.buildPackage (individualCrateArgs // {
+          pname = "lasr_cli";
+          cargoExtraArgs = "--locked --bin lasr_cli";
+          src = fileSetForCrate ./crates/cli;
+        });
+        lasr_node = craneLib.buildPackage (individualCrateArgs // {
+          pname = "lasr_node";
+          cargoExtraArgs = "--locked --bin lasr_node";
+          src = fileSetForCrate ./crates/node;
+        });
+      in
+      {
+        checks = {
+          # Build the crate as part of `nix flake check` for convenience
+          inherit lasr_cli lasr_node;
+
+          # Run clippy (and deny all warnings) on the workspace source,
+          # again, reusing the dependency artifacts from above.
+          #
+          # Note that this is done as a separate derivation so that
+          # we can block the CI if there are issues here, but not
+          # prevent downstream consumers from building our crate by itself.
+          workspace-clippy = craneLib.cargoClippy (commonArgs // {
+            inherit cargoArtifacts;
+            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+          });
+
+          workspace-doc = craneLib.cargoDoc (commonArgs // {
+            inherit cargoArtifacts;
+          });
+
+          # Check formatting
+          workspace-fmt = craneLib.cargoFmt {
+            inherit src;
+          };
+
+          # Audit dependencies
+          workspace-audit = craneLib.cargoAudit {
+            inherit src advisory-db;
+          };
+
+          # Audit licenses
+          workspace-deny = craneLib.cargoDeny {
+            inherit src;
+          };
+
+          # Run tests with cargo-nextest
+          # Consider setting `doCheck = false` on other crate derivations
+          # if you do not want the tests to run twice
+          workspace-nextest = craneLib.cargoNextest (commonArgs // {
+            inherit cargoArtifacts;
+            partitions = 1;
+            partitionType = "count";
+          });
+        };
+
+        packages = {
+          inherit lasr_cli lasr_node;
+        } // lib.optionalAttrs (!pkgs.stdenv.isDarwin) {
+          workspace-llvm-coverage = craneLib.cargoLlvmCov (commonArgs // {
+            inherit cargoArtifacts;
+          });
+        };
+
+        apps = {
+          lasr_cli = flake-utils.lib.mkApp {
+            drv = lasr_cli;
+          };
+          lasr_node = flake-utils.lib.mkApp {
+            drv = lasr_node;
+          };
+        };
+
+        devShells.default = craneLib.devShell {
+          # Inherit inputs from checks.
+          checks = self.checks.${system};
+
+          # Extra inputs can be added here; cargo and rustc are provided by default.
+          #
+          # In addition, these packages and the `rustToolchain` are inherited from checks above:
+          # cargo-audit
+          # cargo-deny
+          # cargo-nextest
+          packages = with pkgs; [
+            # ripgrep
+            nil # nix lsp
+            nixpkgs-fmt # nix formatter
+          ];
+        };
+
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -321,6 +321,7 @@
             # cargo-nextest
             packages = with pkgs; [
               # ripgrep
+              taplo
               nil # nix lsp
               nixpkgs-fmt # nix formatter
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,7 @@
 {
-  description = "Versatus rust-based project template.";
+  description = ''
+    A nix flake for development, and deployment of a LASR node.
+  '';
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";

--- a/nixos/modules/deployments/README.md
+++ b/nixos/modules/deployments/README.md
@@ -1,0 +1,119 @@
+# NixOS Deployments
+
+## Deployment Processes
+
+#### DigitalOcean Deployment Process
+
+There are many ways to deploy NixOS images to server providers, but DigitalOcean is slightly more nuanced.
+The server identity must be maintained between operating system updates, e.g. an Ubuntu 24.04 installation
+cannot be converted to a NixOS 24.04 installation. This is not a problem for other server providers since
+they don't rely on the OS as part of their API. That said here is how we are deploying to DigitalOcean
+servers with NixOS:
+
+1. NixOS images are created for each server
+2. The images are uploaded to DigitalOcean via API, old images are deleted
+3. The existing servers are rebuilt with the new images
+4. A `systemd` startup script runs upon successful server start which deploys the `lasr_node`
+5. This process continues automatically, pulling the most recent changes from the `lasr` repository on a nightly and bi-weekly basis
+
+## Local Development
+It's possible to test your changes to a server locally by starting a NixOS virtual machine environment.
+
+### NixOS VM Linux
+Linux users have an easy time of this, and can simply `nix build .#<nixos-vm>`, then execute the resulting binary `./result/bin/<run-nixos-vm>`,
+assuming they already have a nix installation.
+
+### NixOS VM Darwin
+Darwin users worry not, there is a fairly straight-forward solution with `nix-darwin`.
+
+There are two resources we recommend for getting started with `nix-darwin` which should be followed in this order:
+1. [nix-darwin setup](https://nixcademy.com/2024/01/15/nix-on-macos/#step-2-going-declarative-with-nix-darwin) 
+2. [nix-darwin linux builder](https://nixcademy.com/2024/02/12/macos-linux-builder/#the-nix-darwin-option)
+
+An example of a finalized `nix-darwin` flake, which enables the `linux-builder` functionality can be found at [nix-darwin-example](./nix-darwin).
+From this point, the steps for running the virtual environment are [the same as Linux](#nixos-vm-linux)! 🎉
+```sh
+nix build .#<nixos-vm>
+./result/bin/<run-nixos-vm>
+```
+
+## Rebuilding The NixOS Server
+**Be aware that changes to the server with these methods are semi-permanent at best. To add permanent changes please file
+an issue and pull request that closes said issue.**
+
+### Before Rebuilding...
+Be aware that unless the packages need to be made available semi-permanently on the server,
+using the `nix-shell` feature will open a shell with the packages added to `$PATH`
+and is often the solution if a developer tool is needed only temporarily, or for testing means **while on the server**.
+> For more commands please consult the manual: `nix-shell --help`.
+
+```sh
+ssh <user>@<ip-address>
+# make packages available on the current $PATH (exiting the shell will remove them)
+nix-shell -p <package-name1> <package-name2>
+# or if just needing to run a program once
+nix-shell --run "command arg1 arg2 ..."
+```
+
+In the case of needing to update the configuration on a development server where you may be testing new features, etc., 
+there are two main ways to apply your changes, but both rely on the `nixos-rebuild switch` command with the option `--flake`.
+
+The first instinct for seasoned NixOS users would be to edit, and rebuild as if it was a local system, however this ins't
+the correct way to go about it when dealing with NixOS servers. I've tentatively added instructions on how to properly go
+about rebuilding the system in the `configuration.nix` file, which (on the server) can be found at `/etc/nixos/configuration.nix`,
+the contents of which are more or less as follows:
+> Note that attempting to rebuild switch _will fail_ since the `configuration.nix` file does not have anything in it except these instructions.
+
+### Rebuild From Your Local Machine
+This will be the most common way of adding **semi-permanent changes**, since it doesn't require the server
+itself to be aware of the original configuration, i.e. the versatus.nix git repository.
+Likely the changes that will often be made are to the packages included on the server,
+and those packages should be added under `environment.systemPackages` in `deployments/<name-of-image>/common/default.nix`.
+This command is especially helpful when needing to test changes that will eventually be applied permanently
+to the server image documented in the [Deployment Processes](#deployment-processes).
+
+To rebuild the configuration on a server please update your local copy of
+the configuration you are trying to change in the nix flake, then target the server
+you would like to rebuild with that configuration from your machine.
+
+```sh
+nixos-rebuild \
+  --flake .#<name-of-configuration> \
+  --build-host <user>@<ip-address> \
+  --target-host <user>@<ip-address> \
+  switch
+```
+
+Additionally, MacOS users must pass the `--fast` flag.
+The build host and target host will be the same, and if the user is not `root`, you must
+also pass it the `--use-remote-sudo` flag, assuming the user has sudo privileges.
+
+### Rebuild From The Server
+If rebuilding from the server itself, you must have a copy of the original flake used
+to produce the system configuration you are on.
+
+```sh
+ssh <user>@<ip-address>
+git clone <flake-repository>
+```
+
+Make your changes and be sure to add new files to git, otherwise the flake will not apply them.
+Then rebuild from the flake:
+
+```sh
+git add -A
+nixos-rebuild switch --flake .#<name-of-configuration>
+```
+
+## Troubleshooting
+
+### Unable To Connect After Server Or VM Rebuild
+After rebuilding the server with `nixos-rebuild`, or the server is rebuilt from a newer
+version of the NixOS image, you may encounter an error when attempting to connect to the
+server via SSH. Multiple attempts of this will prompt you with a warning of potential
+"man-in-the-middle" attacks. To reset your relationship with the server navigate to your
+`~/.ssh` folder, and remove the server's host keys from the `known_hosts` file. You should
+be able to now connect to the server, which will prompt you to add the new keys to `~/.ssh/known_hosts`. 
+The same can happen when developing on local NixOS VMs. The solution is the same, but in
+addition the `.qcow2` file that is produced after loading the image can be removed if
+system state does not need to be restored from the previous boot.

--- a/nixos/modules/deployments/README.md
+++ b/nixos/modules/deployments/README.md
@@ -2,19 +2,18 @@
 
 ## Deployment Processes
 
-#### DigitalOcean Deployment Process
+Deployment processes vary between server providers.
 
-There are many ways to deploy NixOS images to server providers, but DigitalOcean is slightly more nuanced.
-The server identity must be maintained between operating system updates, e.g. an Ubuntu 24.04 installation
-cannot be converted to a NixOS 24.04 installation. This is not a problem for other server providers since
-they don't rely on the OS as part of their API. That said here is how we are deploying to DigitalOcean
-servers with NixOS:
+### DigitalOcean Deployment Process
 
 1. NixOS images are created for each server
 2. The images are uploaded to DigitalOcean via API, old images are deleted
 3. The existing servers are rebuilt with the new images
-4. A `systemd` startup script runs upon successful server start which deploys the `lasr_node`
-5. This process continues automatically, pulling the most recent changes from the `lasr` repository on a nightly and bi-weekly basis
+4. `systemd` startup scripts run upon successful server start which spin up the node
+5. This process continues automatically, pulling the most recent changes from the repository on a release cycle
+
+> Note: It is now also possible to push a NixOS deployment to a server, without the DigitalOcean API via [nixos-anywhere](https://nix-community.github.io/nixos-anywhere/).
+> Some configuration examples can be found at https://github.com/nix-community/nixos-anywhere-examples/.
 
 ## Local Development
 It's possible to test your changes to a server locally by starting a NixOS virtual machine environment.
@@ -30,7 +29,7 @@ There are two resources we recommend for getting started with `nix-darwin` which
 1. [nix-darwin setup](https://nixcademy.com/2024/01/15/nix-on-macos/#step-2-going-declarative-with-nix-darwin) 
 2. [nix-darwin linux builder](https://nixcademy.com/2024/02/12/macos-linux-builder/#the-nix-darwin-option)
 
-An example of a finalized `nix-darwin` flake, which enables the `linux-builder` functionality can be found at [nix-darwin-example](./nix-darwin).
+An example of a finalized `nix-darwin` flake, which enables the `linux-builder` functionality can be found at [nix-darwin-example](https://github.com/versatus/versatus.nix/tree/master/nix-darwin).
 From this point, the steps for running the virtual environment are [the same as Linux](#nixos-vm-linux)! 🎉
 ```sh
 nix build .#<nixos-vm>

--- a/nixos/modules/deployments/common/default.nix
+++ b/nixos/modules/deployments/common/default.nix
@@ -1,0 +1,436 @@
+{ pkgs, ... }:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  # Pull the PD server image from dockerhub
+  pd-image =
+    let
+      name = "pingcap/pd";
+      platformSha256 = {
+        "aarch64-linux" = "sha256-+IBB5p1M8g3fLjHbF90vSSAoKUidl5cdkpTulkzlMAc=";
+        "x86_64-linux" = "sha256-xNPJrv8y6vjAPNvn9lAkghCfRGUDiBfRCUBsEYvb49Q=";
+      }."${system}" or (builtins.throw "Unsupported platform for docker image ${name}, must either be arm64 or amd64 Linux: found ${system}");
+    in
+    pkgs.dockerTools.pullImage {
+      imageName = name;
+      imageDigest = "sha256:0e87d077d0fd92903e26a6ebeda633d6979380aac6fc76aa24c6a02d25a404f6";
+      sha256 = platformSha256;
+      finalImageTag = "latest";
+      finalImageName = name;
+    };
+  # Starts the placement driver server for TiKV.
+  # NOTE: This is a global script, which is run by default and is only
+  # necessary in scenarios where the server does not start automatically.
+  start-pd-server = pkgs.writeShellScriptBin "start-pd-server.sh" ''
+    docker run -d --name pd-server --network host pingcap/pd:latest \
+        --name="pd1" \
+        --data-dir="/pd1" \
+        --client-urls="http://0.0.0.0:2379" \
+        --peer-urls="http://0.0.0.0:2380" \
+        --advertise-client-urls="http://0.0.0.0:2379" \
+        --advertise-peer-urls="http://0.0.0.0:2380"
+  '';
+  # Pull the TiKV server image from dockerhub
+  tikv-image =
+    let
+      name = "pingcap/tikv";
+      platformSha256 = {
+        "aarch64-linux" = "sha256-JbogHq9FLfm7x08xkwiDF0+YyUKRXF34vHty+ZxIZh0=";
+        "x86_64-linux" = "sha256-udLF3mAuUU08QX2Tg/mma9uu0JdtdJuxK3R1bqdKjKk=";
+      }.${system} or (builtins.throw "Unsupported platform for docker image ${name}, must either be arm64 or amd64 Linux: found ${system}");
+    in
+    pkgs.dockerTools.pullImage {
+      imageName = name;
+      imageDigest = "sha256:e68889611930cc054acae5a46bee862c4078af246313b414c1e6c4671dceca63";
+      sha256 = platformSha256;
+      finalImageTag = "latest";
+      finalImageName = name;
+    };
+  # Starts the TiKV server.
+  # NOTE: This is a global script, which is run by default and is only
+  # necessary in scenarios where the server does not start automatically.
+  start-tikv-server = pkgs.writeShellScriptBin "start-tikv-server.sh" ''
+    docker run -d --name tikv-server --network host pingcap/tikv:latest \
+        --addr="127.0.0.1:20160" \
+        --advertise-addr="127.0.0.1:20160" \
+        --data-dir="/tikv" \
+        --pd="http://127.0.0.1:2379"
+  '';
+  busybox-stream =
+    let
+      name = "busybox";
+      tag = "latest";
+      platformSha256 = {
+        "aarch64-linux" = "sha256-Oq9xmrdoAJvwQl9WOBkJFhacWHT9JG0B384gaHrimL8=";
+        "x86_64-linux" = "sha256-Oq9xmrdoAJvwQl9WOBkJFhacWHT9JG0B384gaHrimL8=";
+      }.${system} or (builtins.throw "Unsupported platform for docker image ${name}, must either be arm64 or amd64 Linux: found ${system}");
+      busyboxImage = pkgs.dockerTools.pullImage {
+        imageName = name;
+        imageDigest = "sha256:50aa4698fa6262977cff89181b2664b99d8a56dbca847bf62f2ef04854597cf8";
+        sha256 = platformSha256;
+        finalImageTag = tag;
+        finalImageName = name;
+      };
+    in
+    pkgs.dockerTools.streamLayeredImage {
+      name = name;
+      tag = tag;
+      fromImage = busyboxImage;
+      config.Cmd = [ "busybox" ];
+    };
+
+  # Creates the working directory, scripts & initializes the IPFS node.
+  # NOTE: This is a global script, which is run by default and is only
+  # necessary in scenarios where the systemd service fails.
+  setup-working-dir = pkgs.writeShellScriptBin "setup-working-dir.sh" ''
+    if [ -e "/app" ]; then
+      echo "Working directory already exists."
+      exit 0
+    fi
+
+    mkdir -p /app/bin
+    mkdir -p /app/tmp/kubo
+
+    cd /app
+    printf "${procfile.text}" > "${procfile.name}"
+    git clone https://github.com/versatus/lasr.git
+
+    cd /app/bin
+    printf "${ipfs-config.text}" > "${ipfs-config.name}"
+    printf "${start-ipfs.text}" > "${start-ipfs.name}"
+    printf "${start-lasr.text}" > "${start-lasr.name}"
+    printf "${start-overmind.text}" > "${start-overmind.name}"
+
+    for file in ./*; do
+      chmod +x "$file"
+    done
+
+    cd /app/tmp/kubo
+    export IPFS_PATH=/app/tmp/kubo
+    ipfs init
+
+    echo "Done"
+    exit 0
+  '';
+  # Initializes lasr_node environment variables and persists them between system boots.
+  # NOTE: This is a global script, which is run by default and is only
+  # necessary in scenarios where the systemd service fails.
+  init-env = pkgs.writeShellScriptBin "init-env.sh" ''
+    if [ -e "\$HOME/.bashrc" ]; then
+      echo "Environment already initialized."
+      exit 0
+    fi
+
+    secret_key=$(lasr_cli wallet new | jq '.secret_key')
+    block_path="/app/blocks_processed.dat"
+    eth_rpc_url="https://u0anlnjcq5:xPYLI9OMwxRqJZqhfgEiKMeGdpVjGduGKmMCNBsu46Y@u0auvfalma-u0j1mdxq0w-rpc.us0-aws.kaleido.io/" 
+    eo_contract=0x563f0efeea703237b32ae7f66123b864f3e46a3c
+    compute_rpc_url=ws://localhost:9125 
+    storage_rpc_url=ws://localhost:9126
+    batch_interval=180
+    ipfs_path="/app/tmp/kubo"
+    runsc_bin_path="${pkgs.gvisor}/bin/runsc"
+    grpcurl_bin_path="${pkgs.grpcurl}/bin/grpcurl"
+    echo "set -o noclobber" > ~/.bashrc
+    echo "export SECRET_KEY=$secret_key" >> ~/.bashrc
+    echo "export BLOCKS_PROCESSED_PATH=$block_path" >> ~/.bashrc
+    echo "export ETH_RPC_URL=$eth_rpc_url" >> ~/.bashrc
+    echo "export EO_CONTRACT_ADDRESS=$eo_contract" >> ~/.bashrc
+    echo "export COMPUTE_RPC_URL=$compute_rpc_url" >> ~/.bashrc
+    echo "export STORAGE_RPC_URL=$storage_rpc_url" >> ~/.bashrc
+    echo "export BATCH_INTERVAL=$batch_interval" >> ~/.bashrc
+    echo "export IPFS_PATH=$ipfs_path" >> ~/.bashrc
+    echo "export RUNSC_BIN_PATH=$runsc_bin_path" >> ~/.bashrc
+    echo "export GRPCURL_BIN_PATH=$grpcurl_bin_path" >> ~/.bashrc
+    echo "[[ \$- == *i* && -f \"\$HOME/.bashrc\" ]] && source \"\$HOME/.bashrc\"" > ~/.bash_profile
+
+    source ~/.bashrc
+    echo "Done"
+    exit 0
+  '';
+  # Configure addresses and gateway for IPFS daemon.
+  ipfs-config =
+    let
+      ipfs = "${pkgs.ipfs}/bin/ipfs";
+    in
+    pkgs.writeTextFile {
+      name = "ipfs-config.sh";
+      text = ''
+        ## The shell in the go-ipfs container is busybox, so a version of ash
+        ## Shellcheck might warn on things POSIX sh cant do, but ash can
+        ## In Shellcheck, ash is an alias for dash, but busybox ash can do more than dash 
+        ## https://github.com/koalaman/shellcheck/blob/master/src/ShellCheck/Data.hs#L134
+
+        ## Uncomment this section to customise the gateway configuration
+        # echo "ipfs-config: setting Gateway config"
+        # ${ipfs} config --json Gateway '{
+        #         "HTTPHeaders": {
+        #             "Access-Control-Allow-Origin": [
+        #                 "*"
+        #             ],
+        #         }
+        #     }'
+        ## Obviously you should use your own domains here, but I thought it instructive to show path and 
+        ## subdomain gateways here with the widely known PL domains
+        
+        ## Disable hole punching
+        ${ipfs} config --json Swarm.RelayClient.Enabled true
+        ${ipfs} config --json Swarm.EnableHolePunching true
+
+        ## Bind API to all interfaces so that fly proxy for the Kubo API works
+        ${ipfs} config Addresses.API --json '["/ip4/0.0.0.0/tcp/5001", "/ip6/::/tcp/5001"]'
+
+        ## Maybe you need to listen on IPv6 too? Some clouds use it for internal networking
+        ${ipfs} config --json Addresses.Gateway '["/ip4/0.0.0.0/tcp/8080", "/ip6/::/tcp/8080"]'
+
+        ## In fly.io there's no way to know the public IPv4 so it has to be manually configured to be announced
+        ## Note that it must be 1-1, you can't point at multiple go-ipfs nodes and expect it to work
+        ${ipfs} config --json Addresses.AppendAnnounce '["/ip4/167.99.20.121/tcp/4001", "/ip4/167.99.20.121/tcp/4002/ws", "/ip6/2a09:8280:1::1c:fb3f/tcp/4001", "/ip6/2a09:8280:1::1c:fb3f/tcp/4002/ws", "/dns4/versatus-lasr-ipfs.fly.dev/tcp/443/wss"]'
+        ${ipfs} config Swarm.Transports.Network.Websocket --json true
+        ${ipfs} config Swarm.Transports.Network.WebTransport --json true
+        ${ipfs} config --json Addresses.Swarm '["/ip4/0.0.0.0/tcp/4001", "/ip4/0.0.0.0/tcp/4002/ws", "/ip4/0.0.0.0/udp/4003/quic/webtransport", "/ip6/::/tcp/4001", "/ip6/::/tcp/4002/ws", "/ip6/::/udp/4003/quic/webtransport", "/ip4/0.0.0.0/udp/4001/quic", "/ip6/::/udp/4001/quic"]'
+        ${ipfs} config Swarm.ResourceMgr.Enabled --json true
+        ${ipfs} config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://167.99.20.121:5001", "http://127.0.0.1:5001", "https://webui.ipfs.io"]'
+        ${ipfs} config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST"]'
+        echo "Finished configuring IPFS."
+      '';
+      executable = true;
+      destination = "/app/bin/ipfs-config.sh";
+    };
+  # Starts kubo IPFS daemon.
+  start-ipfs = pkgs.writeTextFile {
+    name = "start-ipfs.sh";
+    text = ''
+      IPFS_PATH=/app/tmp/kubo ipfs daemon
+    '';
+    executable = true;
+    destination = "/app/bin/start-ipfs.sh";
+  };
+  # Starts the lasr_node from the release build specified by the nix flake.
+  start-lasr = pkgs.writeTextFile {
+    name = "start-lasr.sh";
+    text = ''
+      PREFIX=/app/lasr
+      cd $PREFIX
+
+      # For local development:
+      # The default behaviour will use the binary specified by the nix flake.
+      # This is important because it retains the flake.lock versioning.
+      # If this is not important to you, exchange the call to lasr_node
+      # with the following:
+      # ./target/release/lasr_node
+      lasr_node
+    '';
+    executable = true;
+    destination = "/app/bin/start-lasr.sh";
+  };
+  # Main process script. Re/starts the node and dependencies.
+  start-overmind = pkgs.writeTextFile {
+    name = "start-overmind.sh";
+    text = ''
+      OVERMIND_CAN_DIE=reset overmind start -D -N /app/Procfile
+    '';
+    executable = true;
+    destination = "/app/bin/start-overmind.sh";
+  };
+  # Overmind's configuration file.
+  # The destination path is automatically created in the nix-store.
+  procfile = pkgs.writeTextFile {
+    name = "Procfile";
+    text = ''
+      ipfs: /app/bin/start-ipfs.sh
+      lasr: sleep 5 && /app/bin/start-lasr.sh
+    '';
+    destination = "/app/Procfile";
+  };
+in
+{
+  # Packages that will be available on the resulting NixOS system.
+  # Please keep these in alphabetical order so packages are easy to find.
+  environment.systemPackages = with pkgs; [
+    curl
+    docker
+    git
+    grpcurl
+    gvisor
+    jq
+    kubo
+    overmind
+    tmux
+    lasr_node
+    lasr_cli
+  ] ++ [
+    init-env
+    ipfs-config
+    procfile
+    setup-working-dir
+    start-ipfs
+    start-lasr
+    start-overmind
+    start-pd-server
+    start-tikv-server
+  ];
+
+  # Enable docker socket
+  virtualisation.docker.enable = true;
+  users.users.root.extraGroups = [ "docker" ];
+  # Automatically start the pd-server & tikv-server on server start
+  virtualisation.oci-containers = {
+    backend = "docker";
+    containers = {
+      pd-server = {
+        image = "pingcap/pd:latest";
+        imageFile = pd-image;
+        extraOptions = [
+          "--network=host"
+        ];
+        cmd = [
+          "--data-dir=/pd1"
+          "--client-urls=http://0.0.0.0:2379"
+          "--peer-urls=http://0.0.0.0:2380"
+          "--advertise-client-urls=http://0.0.0.0:2379"
+          "--advertise-peer-urls=http://0.0.0.0:2380"
+        ];
+      };
+      tikv-server = {
+        dependsOn = [ "pd-server" ];
+        image = "pingcap/tikv:latest";
+        imageFile = tikv-image;
+        extraOptions = [
+          "--network=host"
+        ];
+        cmd = [
+          "--addr=127.0.0.1:20160"
+          "--advertise-addr=127.0.0.1:20160"
+          "--data-dir=/tikv"
+          "--pd=http://127.0.0.1:2379"
+        ];
+      };
+    };
+  };
+
+  # Node services that will run on server start
+  systemd.user.services = {
+    init-env = {
+      description = "Initializes lasr_node environment variables and persists them between system boots.";
+      script = ''
+        if [ -f "\$HOME/.bashrc" ]; then
+          echo "Environment already initialized."
+          exit 0
+        fi
+
+        secret_key=$(${pkgs.lasr_cli}/bin/lasr_cli wallet new | ${pkgs.jq}/bin/jq '.secret_key')
+        block_path="/app/blocks_processed.dat"
+        eth_rpc_url="https://u0anlnjcq5:xPYLI9OMwxRqJZqhfgEiKMeGdpVjGduGKmMCNBsu46Y@u0auvfalma-u0j1mdxq0w-rpc.us0-aws.kaleido.io/" 
+        eo_contract=0x563f0efeea703237b32ae7f66123b864f3e46a3c
+        compute_rpc_url=ws://localhost:9125
+        storage_rpc_url=ws://localhost:9126
+        batch_interval=180
+        ipfs_path="/app/tmp/kubo"
+        runsc_bin_path="${pkgs.gvisor}/bin/runsc"
+        grpcurl_bin_path="${pkgs.grpcurl}/bin/grpcurl"
+        echo "set -o noclobber" > ~/.bashrc
+        echo "export SECRET_KEY=$secret_key" >> ~/.bashrc
+        echo "export BLOCKS_PROCESSED_PATH=$block_path" >> ~/.bashrc
+        echo "export ETH_RPC_URL=$eth_rpc_url" >> ~/.bashrc
+        echo "export EO_CONTRACT_ADDRESS=$eo_contract" >> ~/.bashrc
+        echo "export COMPUTE_RPC_URL=$compute_rpc_url" >> ~/.bashrc
+        echo "export STORAGE_RPC_URL=$storage_rpc_url" >> ~/.bashrc
+        echo "export BATCH_INTERVAL=$batch_interval" >> ~/.bashrc
+        echo "export IPFS_PATH=$ipfs_path" >> ~/.bashrc
+        echo "export RUNSC_BIN_PATH=$runsc_bin_path" >> ~/.bashrc
+        echo "export GRPCURL_BIN_PATH=$grpcurl_bin_path" >> ~/.bashrc
+        echo "[[ \$- == *i* && -f \"\$HOME/.bashrc\" ]] && source \"\$HOME/.bashrc\"" > ~/.bash_profile
+        echo "Successfully initialized lasr_node environment."
+      '';
+      wantedBy = [ "default.target" ];
+    };
+    ipfs-start = {
+      description = "Setup and start IPFS daemon.";
+      preStart = ''
+        if [ ! -e "/app/tmp/kubo" ]; then
+          mkdir -p /app/tmp/kubo
+          cd /app/tmp/kubo
+          export IPFS_PATH=/app/tmp/kubo
+          "${pkgs.kubo}/bin/ipfs" init
+          echo "Initialized IPFS."
+          IPFS_CONFIG="${ipfs-config}/app/bin/ipfs-config.sh"
+          echo "Configuring IPFS from ipfs-config path: $IPFS_CONFIG"
+          "$IPFS_CONFIG"
+          echo "IPFS ready."
+        else
+          echo "IPFS already initialized and configured. IPFS ready."
+        fi
+      '';
+      script = ''
+        sleep 2
+        IPFS_PATH=/app/tmp/kubo "${pkgs.kubo}/bin/ipfs" daemon
+      '';
+      wantedBy = [ "node-start.service" ];
+    };
+    node-start = {
+      description = "Start the lasr_node process.";
+      after = [ "init-env.service" "ipfs-start.service" ];
+      preStart =
+        let
+          # nix-store paths are resolved on user login, but here we have to give the absolute paths.
+          git = "${pkgs.git}/bin/git";
+          docker = "${pkgs.docker}/bin/docker";
+          sudo = "/run/wrappers/bin/sudo";
+          tar = "/run/current-system/sw/bin/tar";
+        in
+        ''
+          if [ ! -e "/app/bin" ]; then
+            echo "Setting up working directory.."
+            mkdir -p /app/bin
+            mkdir -p /app/payload
+            mkdir -p /app/base_image/busybox
+
+            cd /app
+            printf "${procfile.text}" > "${procfile.name}"
+            ${git} clone https://github.com/versatus/lasr.git
+
+            cd /app/base_image/busybox
+            mkdir --mode=0755 rootfs
+            ${busybox-stream} | ${docker} image load
+            ${docker} export $(${docker} create busybox) | ${sudo} ${tar} -xf - -C rootfs --same-owner --same-permissions
+
+            cd /app/bin
+            printf "${start-ipfs.text}" > "${start-ipfs.name}"
+            printf "${start-lasr.text}" > "${start-lasr.name}"
+            printf "${start-overmind.text}" > "${start-overmind.name}"
+
+            for file in ./*; do
+              chmod +x "$file"
+            done
+
+            # wait for busybox to set up the root filesystem for the program env
+            while [ ! -e "/app/base_image/busybox/rootfs/bin" ]; do
+              echo "Waiting for busybox filesystem to be ready, sleeping for 2s..."
+              sleep 2
+            done
+
+            echo "Working directory '/app' is ready."
+          else
+            echo "Working directory already exists."
+          fi
+        '';
+      script = ''
+        # grace period for all services to finish setup
+        sleep 5
+
+        source "$HOME/.bashrc"
+        cd /app
+        "${pkgs.lasr_node}/bin/lasr_node"
+      '';
+      wantedBy = [ "default.target" ];
+      serviceConfig = {
+        Restart = "always";
+        RestartSec = 5;
+      };
+    };
+  };
+
+  # Before changing, read this first:
+  # https://nixos.org/manual/nixos/stable/options.html#opt-system.stateVersion
+  system.stateVersion = "24.04";
+}

--- a/nixos/modules/deployments/debug/debug-options.nix
+++ b/nixos/modules/deployments/debug/debug-options.nix
@@ -1,0 +1,11 @@
+{ ... }:
+{
+  networking.hostName = "lasr-debug-server";
+
+  # Add your SSH key and comment your username/system-name
+  users.users.root.openssh.authorizedKeys.keys = [
+    # eureka-cpu
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINQ66bGgeELzU/wZjpYxSlKIgMoROQxPx76vGdpS3lwc github.eureka@gmail.com" # dev-one
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAsUzc7Wg9FwImAMPc61K/zO9gvUDJVHwQ0+GTrO1mqJ github.eureka@gmail.com" # critter-tank
+  ];
+}

--- a/nixos/modules/deployments/prod/prod-options.nix
+++ b/nixos/modules/deployments/prod/prod-options.nix
@@ -1,0 +1,5 @@
+{ releaseCycle, ... }:
+{
+  # TODO: Finalize production options for lasr_node server
+  networking.hostName = "lasr-${releaseCycle}-server";
+}

--- a/nixos/overlay.nix
+++ b/nixos/overlay.nix
@@ -1,0 +1,34 @@
+final: prev:
+
+let
+  craneLib = prev.craneLib;
+
+  lasrArgs = {
+    inherit (prev.workspace) src version;
+    pname = prev.workspace.name;
+    strictDeps = true;
+    nativeBuildInputs = [ final.pkg-config ];
+    buildInputs = [
+      final.openssl.dev
+      final.rustToolchain.darwin-pkgs
+    ];
+  };
+
+  # Build *just* the cargo dependencies, so we can reuse
+  # all of that work (e.g. via cachix) when running in CI
+  lasrDeps = craneLib.buildDepsOnly lasrArgs;
+in
+{
+  lasr_node = craneLib.buildPackage (lasrArgs // {
+    pname = "lasr_node";
+    doCheck = false;
+    cargoArtifacts = lasrDeps;
+    cargoExtraArgs = "--locked --bin lasr_node";
+  });
+  lasr_cli = craneLib.buildPackage (lasrArgs // {
+    pname = "lasr_cli";
+    doCheck = false;
+    cargoArtifacts = lasrDeps;
+    cargoExtraArgs = "--locked --bin lasr_cli";
+  });
+}


### PR DESCRIPTION
Part of https://github.com/versatus/versatus.nix/issues/49 which moves the repo-specific logic into its respective repo so that the versatus.nix flake can be used across the org as needed.

What this does:
- Moves the deployment process into the lasr repo from the versatus.nix repo
- Adds developer environment
- Adds checks for cargo licenses, advisories and sources (like crates.io)
- Updates READMEs where applicable
- Adds the potential for a github codespace for newcomers
- Overall increase to maintainability of the project, long term